### PR TITLE
Adding port for TI c28x based microcontrollers

### DIFF
--- a/CCS/C2000_C28x/README.md
+++ b/CCS/C2000_C28x/README.md
@@ -1,0 +1,19 @@
+
+OVERVIEW
+
+This directory contains FreeRTOS port for Texas Instruments C28x based microcontrollers.
+
+The standard demo project to test this port is added at following location:
+FreeRTOS-Partner-Supported-Demos\C2000_F2838x_C28x_CCS\freertos_ex1_c28x_port_val
+
+This port is distributed under MIT open source license.
+
+KNOWN ISSUES:
+Support for "fpu64" is not added yet to the port. The examples should specify "fpu32" as option for floating point.
+
+TOOL CHAIN SUPPORT:
+Code Composer Studio™ IDE (CCS) v11.1.0 or newer
+C2000 Compiler v20.2.1.LTS or newer
+C2000Ware_3_01_00_00 or newer
+FreeRTOSv202112.00
+

--- a/CCS/C2000_C28x/README.md
+++ b/CCS/C2000_C28x/README.md
@@ -4,7 +4,7 @@ OVERVIEW
 This directory contains FreeRTOS port for Texas Instruments C28x based microcontrollers.
 
 The standard demo project to test this port is added at following location:
-FreeRTOS-Partner-Supported-Demos\C2000_F2838x_C28x_CCS\freertos_ex1_c28x_port_val
+FreeRTOS-Community-Supported-Demos\C2000_F2838x_C28x_CCS\freertos_ex1_c28x_port_val
 
 This port is distributed under MIT open source license.
 

--- a/CCS/C2000_C28x/port.c
+++ b/CCS/C2000_C28x/port.c
@@ -1,0 +1,172 @@
+//-------------------------------------------------------------------------------------------------
+// Author: Ivan Zaitsev, ivan.zaitsev@gmail.com
+//
+// This file follows the FreeRTOS distribution license.
+//
+// FreeRTOS is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License (version 2) as published by the
+// Free Software Foundation >>>> AND MODIFIED BY <<<< the FreeRTOS exception.
+//
+// ***************************************************************************
+// >>!   NOTE: The modification to the GPL is included to allow you to     !<<
+// >>!   distribute a combined work that includes FreeRTOS without being   !<<
+// >>!   obliged to provide the source code for proprietary components     !<<
+// >>!   outside of the FreeRTOS kernel.                                   !<<
+// ***************************************************************************
+//
+// FreeRTOS is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  Full license text is available on the following
+// link: http://www.freertos.org/a00114.html
+//-------------------------------------------------------------------------------------------------
+
+//-------------------------------------------------------------------------------------------------
+// Scheduler includes.
+//-------------------------------------------------------------------------------------------------
+#include "FreeRTOS.h"
+#include "task.h"
+
+//-------------------------------------------------------------------------------------------------
+// Implementation of functions defined in portable.h for the C28x port.
+//-------------------------------------------------------------------------------------------------
+
+// Constants required for hardware setup.
+#define portINITIAL_CRITICAL_NESTING  ( ( uint16_t ) 10 )
+#define portFLAGS_INT_ENABLED         ( ( StackType_t ) 0x08 )
+#if defined(__TMS320C28XX_FPU32__)
+# define AUX_REGISTERS_TO_SAVE        19 // XAR + FPU registers
+# define XAR4_REGISTER_POSITION       6  // XAR4 position in AUX registers array
+# define STF_REGISTER_POSITION        10 // STF position in AUX registers array
+#else
+# define AUX_REGISTERS_TO_SAVE        9  // XAR registers only
+# define XAR4_REGISTER_POSITION       5  // XAR4 position in AUX registers array
+#endif
+
+extern uint32_t getSTF( void );
+extern void vApplicationSetupTimerInterrupt( void );
+
+// Each task maintains a count of the critical section nesting depth.  Each
+// time a critical section is entered the count is incremented.  Each time a
+// critical section is exited the count is decremented - with interrupts only
+// being re-enabled if the count is zero.
+//
+// ulCriticalNesting will get set to zero when the scheduler starts, but must
+// not be initialised to zero as this will cause problems during the startup
+// sequence.
+// ulCriticalNesting should be 32 bit value to keep stack alignment unchanged.
+volatile uint32_t ulCriticalNesting = portINITIAL_CRITICAL_NESTING;
+volatile uint16_t bYield = 0;
+volatile uint16_t bPreemptive = 0;
+
+//-------------------------------------------------------------------------------------------------
+// Initialise the stack of a task to look exactly as if
+// timer interrupt was executed.
+//-------------------------------------------------------------------------------------------------
+StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters )
+{
+  uint16_t i;
+  uint16_t base = 0;
+
+  pxTopOfStack[base++]  = 0x0080;  // ST0. PSM = 0(No shift)
+  pxTopOfStack[base++]  = 0x0000;  // T
+  pxTopOfStack[base++]  = 0x0000;  // AL
+  pxTopOfStack[base++]  = 0x0000;  // AH
+  pxTopOfStack[base++]  = 0xFFFF;  // PL
+  pxTopOfStack[base++]  = 0xFFFF;  // PH
+  pxTopOfStack[base++]  = 0xFFFF;  // AR0
+  pxTopOfStack[base++]  = 0xFFFF;  // AR1
+  pxTopOfStack[base++]  = 0x8A08;  // ST1
+  pxTopOfStack[base++]  = 0x0000;  // DP
+  pxTopOfStack[base++] = 0x0000;  // IER
+  pxTopOfStack[base++] = 0x0000;  // DBGSTAT
+  pxTopOfStack[base++] = ((uint32_t)pxCode) & 0xFFFFU;       // PCL
+  pxTopOfStack[base++] = ((uint32_t)pxCode >> 16) & 0x00FFU; // PCH
+  pxTopOfStack[base++] = 0xAAAA;  // Alignment
+  pxTopOfStack[base++] = 0xBBBB;  // Alignment
+
+  // Fill the rest of the registers with dummy values.
+  for(i = 0; i < (2 * AUX_REGISTERS_TO_SAVE); i++)
+  {
+    uint16_t low  = 0x0000;
+    uint16_t high = 0x0000;
+
+    if(i == (2 * XAR4_REGISTER_POSITION))
+    {
+      low  = ((uint32_t)pvParameters) & 0xFFFFU;
+      high = ((uint32_t)pvParameters >> 16) & 0xFFFFU;
+    }
+
+#if defined(__TMS320C28XX_FPU32__)
+    if(i == (2 * STF_REGISTER_POSITION))
+    {
+      uint32_t stf = getSTF();
+
+      low  = stf & 0xFFFFU;
+      high = (stf >> 16) & 0xFFFFU;
+    }
+#endif
+
+    pxTopOfStack[base + i] = low;
+    i++;
+    pxTopOfStack[base + i] = high;
+  }
+
+  base += i;
+
+  // Reserve place for ST1 which will be used in context switch
+  // to set correct SPA bit ASAP.
+  pxTopOfStack[base++] = 0x8A18;  // ST1 with SPA bit set
+  pxTopOfStack[base++] = 0x0000;  // DP
+  pxTopOfStack[base++] = 0x0000;  // placeholder for 32 bit ulCriticalNesting
+  pxTopOfStack[base++] = 0x0000;
+
+  // Return a pointer to the top of the stack we have generated so this can
+  // be stored in the task control block for the task.
+  return pxTopOfStack + base;
+}
+
+//-------------------------------------------------------------------------------------------------
+void vPortEndScheduler( void )
+{
+  // It is unlikely that the TMS320 port will get stopped.
+  // If required simply disable the tick interrupt here.
+}
+
+//-------------------------------------------------------------------------------------------------
+// See header file for description.
+//-------------------------------------------------------------------------------------------------
+BaseType_t xPortStartScheduler(void)
+{
+  vApplicationSetupTimerInterrupt();
+
+  ulCriticalNesting = 0;
+
+#if(configUSE_PREEMPTION == 1)
+  bPreemptive = 1;
+#else
+  bPreemptive = 0;
+#endif
+
+  portENABLE_INTERRUPTS();
+  portRESTORE_FIRST_CONTEXT();
+
+  // Should not get here!
+  return pdFAIL;
+}
+
+//-------------------------------------------------------------------------------------------------
+void vPortEnterCritical( void )
+{
+  portDISABLE_INTERRUPTS();
+  ulCriticalNesting++;
+}
+
+//-------------------------------------------------------------------------------------------------
+void vPortExitCritical( void )
+{
+  ulCriticalNesting--;
+  if( ulCriticalNesting == 0 )
+  {
+    portENABLE_INTERRUPTS();
+  }
+}

--- a/CCS/C2000_C28x/portasm.asm
+++ b/CCS/C2000_C28x/portasm.asm
@@ -1,0 +1,316 @@
+;-------------------------------------------------------------------------------------------------
+; Author: Ivan Zaitsev, ivan.zaitsev@gmail.com
+;
+; This file follows the FreeRTOS distribution license.
+;
+; FreeRTOS is free software; you can redistribute it and/or modify it under
+; the terms of the GNU General Public License (version 2) as published by the
+; Free Software Foundation >>>> AND MODIFIED BY <<<< the FreeRTOS exception.
+;
+; ***************************************************************************
+; >>!   NOTE: The modification to the GPL is included to allow you to     !<<
+; >>!   distribute a combined work that includes FreeRTOS without being   !<<
+; >>!   obliged to provide the source code for proprietary components     !<<
+; >>!   outside of the FreeRTOS kernel.                                   !<<
+; ***************************************************************************
+;
+; FreeRTOS is distributed in the hope that it will be useful, but WITHOUT ANY
+; WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+; FOR A PARTICULAR PURPOSE.  Full license text is available on the following
+; link: http://www.freertos.org/a00114.html
+;-------------------------------------------------------------------------------------------------
+
+  .if __TI_EABI__                      
+  .asg    pxCurrentTCB, _pxCurrentTCB
+  .asg    bYield, _bYield
+  .asg    bPreemptive, _bPreemptive
+  .asg    ulCriticalNesting, _ulCriticalNesting
+  .asg    xTaskIncrementTick, _xTaskIncrementTick
+  .asg    vTaskSwitchContext, _vTaskSwitchContext
+  .asg    portTICK_ISR, _portTICK_ISR
+  .asg    portRESTORE_FIRST_CONTEXT, _portRESTORE_FIRST_CONTEXT
+  .asg    getSTF, _getSTF
+  .endif
+
+  .ref _pxCurrentTCB
+  .ref _bYield
+  .ref _bPreemptive
+  .ref _ulCriticalNesting
+  .ref _xTaskIncrementTick
+  .ref _vTaskSwitchContext
+
+  .def _portTICK_ISR
+  .def _portRESTORE_FIRST_CONTEXT
+
+  .if .TMS320C2800_FPU32 = 1
+
+  .def _getSTF
+
+_getSTF:
+  MOV32   *SP++, STF
+  POP     ACC
+  LRETR
+
+_portRESTORE_FIRST_CONTEXT:
+; Restore stack pointer from new task control block.
+  MOVL    XAR0, #_pxCurrentTCB
+  MOVL    XAR0, *XAR0
+  MOVL    XAR0, *XAR0
+  MOV     @SP, AR0
+
+; Restore XAR4 and RPC from saved task stack.
+; and return to main task function.
+; SP should be set to stack start plus 2 before LRETR.
+  SUBB   SP, #28
+  POP    XAR4
+  SUBB   SP, #14
+  POP    RPC
+  SUBB   SP, #10
+  LRETR
+
+_portTICK_ISR:
+; Save context
+  ASP
+  PUSH    RB
+  PUSH    AR1H:AR0H
+  PUSH    RPC
+  MOVL    *SP++, XT
+  MOVL    *SP++, XAR2
+  MOVL    *SP++, XAR3
+  MOVL    *SP++, XAR4
+  MOVL    *SP++, XAR5
+  MOVL    *SP++, XAR6
+  MOVL    *SP++, XAR7
+  MOV32   *SP++, STF
+  MOV32   *SP++, R0H
+  MOV32   *SP++, R1H
+  MOV32   *SP++, R2H
+  MOV32   *SP++, R3H
+  MOV32   *SP++, R4H
+  MOV32   *SP++, R5H
+  MOV32   *SP++, R6H
+  MOV32   *SP++, R7H
+  PUSH    DP:ST1
+
+; Save critical section nesting counter
+  MOVL    XAR0, #_ulCriticalNesting
+  MOVL    ACC, *XAR0
+  PUSH    ACC
+
+; Save stack pointer in the task control block.
+  MOVL    XAR0, #_pxCurrentTCB
+  MOVL    XAR0, *XAR0
+  MOVL    XAR6, #0     ;set to 0 XAR6 before move the new value of pxTopOfStack
+  MOV     AR6, @SP
+  MOVL    *XAR0, XAR6
+
+; Save IER on stack to avoid corruption.
+; Depending on stack alignment bit IER can be found in two locations.
+  PUSH    ST1
+  POP     AL
+  TBIT    AL, #4
+  SB      SPA_BIT_SET, TC
+  MOV     AR7, *-SP[46]
+  SB      SAVE_IER, UNC
+SPA_BIT_SET:
+  MOV     AR7, *-SP[48]
+SAVE_IER:
+  MOVL    *SP++, XAR7
+
+; Increment tick counter if timer tick is executed.
+; Don't increment if explicitly yielded.
+  MOVL    XAR0, #_bYield
+  MOV     ACC, *XAR0
+  SB      RESET_YIELD_FLAG, NEQ
+  LCR     _xTaskIncrementTick
+
+RESET_YIELD_FLAG:
+; Save bYield in AR1 and clear it in memory.
+  MOV     AR1, ACC
+  MOV     ACC, #0
+  MOV     *XAR0, ACC
+
+; Do context switch if bYield=1 or bPreemptive=1
+  MOVL    XAR0, #_bPreemptive
+  MOV     ACC, *XAR0
+  CMPB    AL, #0x1
+  SB      CONTEXT_SWITCH, EQ
+  MOV     ACC, AR1
+  CMPB    AL, #0x1
+  SB      SKIP_CONTEXT_SWITCH, NEQ
+
+CONTEXT_SWITCH:
+  LCR     _vTaskSwitchContext
+
+SKIP_CONTEXT_SWITCH:
+; Restore IER value from stack.
+  MOVL    XAR7, *--SP
+
+; Restore stack pointer from new task control block.
+  MOVL    XAR0, #_pxCurrentTCB
+  MOVL    XAR0, *XAR0
+  MOVL    XAR0, *XAR0
+  MOV     @SP, AR0
+
+; Restore critical section nesting counter
+  MOVL    XAR0, #_ulCriticalNesting
+  POP     ACC
+  MOVL    *XAR0, ACC
+
+; Update IER value in target context.
+; Depending on stack alignment bit IER can be found in two locations.
+  POP     DP:ST1
+  PUSH    ST1
+  POP     AL
+  TBIT    AL, #4
+  SB      SPA_BIT_SET_RESTORE, TC
+  MOV     *-SP[42], AR7
+  SB      RESTORE_CONTEXT, UNC
+SPA_BIT_SET_RESTORE:
+  MOV     *-SP[44], AR7
+
+RESTORE_CONTEXT:
+  MOV32   R7H, *--SP
+  MOV32   R6H, *--SP
+  MOV32   R5H, *--SP
+  MOV32   R4H, *--SP
+  MOV32   R3H, *--SP
+  MOV32   R2H, *--SP
+  MOV32   R1H, *--SP
+  MOV32   R0H, *--SP
+  MOV32   STF, *--SP
+  MOVL    XAR7, *--SP
+  MOVL    XAR6, *--SP
+  MOVL    XAR5, *--SP
+  MOVL    XAR4, *--SP
+  MOVL    XAR3, *--SP
+  MOVL    XAR2, *--SP
+  MOVL    XT, *--SP
+  POP     RPC
+  POP     AR1H:AR0H
+  POP     RB
+  NASP
+  IRET
+
+  .else
+
+_portRESTORE_FIRST_CONTEXT:
+; Restore stack pointer from new task control block.
+  MOVL    XAR0, #_pxCurrentTCB
+  MOVL    XAR0, *XAR0
+  MOVL    XAR0, *XAR0
+  MOV     @SP, AR0
+
+; Restore XAR4 and RPC from saved task stack.
+; and return to main task function.
+; SP should be set to stack start plus 2 before LRETR.
+  SUBB   SP, #10
+  POP    XAR4
+  SUBB   SP, #12
+  POP    RPC
+  SUBB   SP, #10
+  LRETR
+
+_portTICK_ISR:
+; Save context
+  ASP
+  PUSH    AR1H:AR0H
+  PUSH    RPC
+  MOVL    *SP++, XT
+  MOVL    *SP++, XAR2
+  MOVL    *SP++, XAR3
+  MOVL    *SP++, XAR4
+  MOVL    *SP++, XAR5
+  MOVL    *SP++, XAR6
+  MOVL    *SP++, XAR7
+  PUSH    DP:ST1
+
+; Save critical section nesting counter
+  MOVL    XAR0, #_ulCriticalNesting
+  MOVL    ACC, *XAR0
+  PUSH    ACC
+
+; Save stack pointer in the task control block.
+  MOVL    XAR0, #_pxCurrentTCB
+  MOVL    XAR0, *XAR0
+  MOVL    XAR6, #0     ;set to 0 XAR6 before move the new value of pxTopOfStack
+  MOV     AR6, @SP
+  MOVL    *XAR0, XAR6
+
+; Save IER on stack to avoid corruption.
+  PUSH    ST1
+  POP     AL
+  TBIT    AL, #4
+  SB      SPA_BIT_SET, TC
+  MOV     AR7, *-SP[26]
+  SB      SAVE_IER, UNC
+SPA_BIT_SET:
+  MOV     AR7, *-SP[28]
+SAVE_IER:
+  MOVL    *SP++, XAR7
+
+; Increment tick counter if timer tick is executed.
+; Don't increment if explicitly yielded.
+  MOVL    XAR0, #_bYield
+  MOV     ACC, *XAR0
+  SB      RESET_YIELD_FLAG, NEQ
+  LCR     _xTaskIncrementTick
+
+RESET_YIELD_FLAG:
+; Save bYield in AR1 and clear it in memory.
+  MOV     AR1, ACC
+  MOV     ACC, #0
+  MOV     *XAR0, ACC
+
+; Do context switch if bYield=1 or bPreemptive=1
+  MOVL    XAR0, #_bPreemptive
+  MOV     ACC, *XAR0
+  CMPB    AL, #0x1
+  SB      CONTEXT_SWITCH, EQ
+  MOV     ACC, AR1
+  CMPB    AL, #0x1
+  SB      SKIP_CONTEXT_SWITCH, NEQ
+
+CONTEXT_SWITCH:
+  LCR     _vTaskSwitchContext
+
+SKIP_CONTEXT_SWITCH:
+; Restore IER value from stack.
+  MOVL    XAR7, *--SP
+
+; Restore stack pointer from new task control block.
+  MOVL    XAR0, #_pxCurrentTCB
+  MOVL    XAR0, *XAR0
+  MOVL    XAR0, *XAR0
+  MOV     @SP, AR0
+
+; Restore critical section nesting counter
+  MOVL    XAR0, #_ulCriticalNesting
+  POP     ACC
+  MOVL    *XAR0, ACC
+
+; Update IER value in target context.
+  POP     DP:ST1
+  PUSH    ST1
+  POP     AL
+  TBIT    AL, #4
+  SB      SPA_BIT_SET_RESTORE, TC
+  MOV     *-SP[22], AR7
+  SB      RESTORE_CONTEXT, UNC
+SPA_BIT_SET_RESTORE:
+  MOV     *-SP[24], AR7
+
+RESTORE_CONTEXT:
+  MOVL    XAR7, *--SP
+  MOVL    XAR6, *--SP
+  MOVL    XAR5, *--SP
+  MOVL    XAR4, *--SP
+  MOVL    XAR3, *--SP
+  MOVL    XAR2, *--SP
+  MOVL    XT, *--SP
+  POP     RPC
+  POP     AR1H:AR0H
+  NASP
+  IRET
+
+  .endif

--- a/CCS/C2000_C28x/portmacro.h
+++ b/CCS/C2000_C28x/portmacro.h
@@ -1,0 +1,103 @@
+//-------------------------------------------------------------------------------------------------
+// Author: Ivan Zaitsev, ivan.zaitsev@gmail.com
+//
+// This file follows the FreeRTOS distribution license.
+//
+// FreeRTOS is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License (version 2) as published by the
+// Free Software Foundation >>>> AND MODIFIED BY <<<< the FreeRTOS exception.
+//
+// ***************************************************************************
+// >>!   NOTE: The modification to the GPL is included to allow you to     !<<
+// >>!   distribute a combined work that includes FreeRTOS without being   !<<
+// >>!   obliged to provide the source code for proprietary components     !<<
+// >>!   outside of the FreeRTOS kernel.                                   !<<
+// ***************************************************************************
+//
+// FreeRTOS is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE.  Full license text is available on the following
+// link: http://www.freertos.org/a00114.html
+//-------------------------------------------------------------------------------------------------
+
+#ifndef PORTMACRO_H
+#define PORTMACRO_H
+
+//-------------------------------------------------------------------------------------------------
+// Port specific definitions.
+//
+// The settings in this file configure FreeRTOS correctly for the
+// given hardware and compiler.
+//
+// These settings should not be altered.
+//-------------------------------------------------------------------------------------------------
+
+//-------------------------------------------------------------------------------------------------
+// Hardware includes
+//-------------------------------------------------------------------------------------------------
+
+//-------------------------------------------------------------------------------------------------
+// Type definitions.
+//-------------------------------------------------------------------------------------------------
+#define portCHAR        uint16_t
+#define portFLOAT       float
+#define portDOUBLE      double
+#define portLONG        uint32_t
+#define portSHORT       uint16_t
+#define portBASE_TYPE   uint16_t
+#define uint8_t         uint16_t
+#define int8_t          int16_t
+#define portSTACK_TYPE  uint16_t
+
+typedef portSTACK_TYPE StackType_t;
+typedef int16_t        BaseType_t;
+typedef uint16_t       UBaseType_t;
+
+#if( configUSE_16_BIT_TICKS == 1 )
+  typedef uint16_t TickType_t;
+  #define portMAX_DELAY ( TickType_t ) 0xffff
+#else
+  typedef uint32_t TickType_t;
+  #define portMAX_DELAY ( TickType_t ) 0xffffffffUL
+#endif
+
+//-------------------------------------------------------------------------------------------------
+// Interrupt control macros.
+//-------------------------------------------------------------------------------------------------
+#define portDISABLE_INTERRUPTS()  __asm(" setc INTM")
+#define portENABLE_INTERRUPTS()   __asm(" clrc INTM")
+
+//-------------------------------------------------------------------------------------------------
+// Critical section control macros.
+//-------------------------------------------------------------------------------------------------
+extern void vPortEnterCritical( void );
+extern void vPortExitCritical( void );
+#define portENTER_CRITICAL()  vPortEnterCritical()
+#define portEXIT_CRITICAL()   vPortExitCritical()
+
+//-------------------------------------------------------------------------------------------------
+// Task utilities.
+//-------------------------------------------------------------------------------------------------
+#define portYIELD() do{bYield = 1; __asm(" INTR INT14");}while(0)
+#define portYIELD_FROM_ISR( x )  do{if(x == pdTRUE){bYield = 1; __asm(" OR IFR, #0x2000");}}while(0)
+
+extern void portTICK_ISR( void );
+extern void portRESTORE_FIRST_CONTEXT( void );
+extern void vTaskSwitchContext( void );
+extern volatile uint16_t bYield;
+
+//-------------------------------------------------------------------------------------------------
+// Hardware specifics.
+//-------------------------------------------------------------------------------------------------
+#define portBYTE_ALIGNMENT      2
+#define portSTACK_GROWTH        ( 1 )
+#define portTICK_PERIOD_MS      ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+#define portNOP()               __asm(" NOP")
+
+//-------------------------------------------------------------------------------------------------
+// Task function macros as described on the FreeRTOS.org WEB site.
+//-------------------------------------------------------------------------------------------------
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters ) void vFunction( void *pvParameters )
+#define portTASK_FUNCTION( vFunction, pvParameters ) void vFunction( void *pvParameters )
+
+#endif /* PORTMACRO_H */


### PR DESCRIPTION
FreeRTOS port for TI c28x based microcontrollers

Description
-----------
This pull request consists of FreeRTOS c28x port related files. This port has been tested with the standard demo test project as explained in following link: https://github.com/FreeRTOS/FreeRTOS/blob/main/FreeRTOS/Demo/ThirdParty/Template/README.md

The test project is available in a separate pull request: https://github.com/FreeRTOS/FreeRTOS-Community-Supported-Demos/pull/5

Test Steps
-----------
To run the demos on TMDSCNCD28388D controlcard, the following steps are required:
- Install Code Compser Studio(CCS): https://www.ti.com/tool/CCSTUDIO
- Install latest C2000Ware package: https://www.ti.com/tool/C2000WARE
- Update the C2000WARE_ROOT and FreeRTOS_ROOT path variable in the example projectspec files available at following location in the repo: FreeRTOS-Partner-Supported-Demos\C2000_F2838x_C28x_CCS\CCS
- Import the example project file in CCS
- Build and debug the project

Known Issues
-----------
Support for "fpu64" is not added yet to the port. The examples should specify "fpu32" as option for floating point.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
