### PR TITLE
z88dk Z180 - refresh to 10.5.1+ and unify inline assembly

### DIFF
--- a/Z88DK/Z180/port.c
+++ b/Z88DK/Z180/port.c
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.3
+ * FreeRTOS Kernel V10.5.1+
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -42,29 +42,21 @@ any details of its type. */
 
 typedef void TCB_t;
 extern volatile TCB_t * volatile pxCurrentTCB;
+
 /*-----------------------------------------------------------*/
 
 /*
- * Macro to save all the general purpose registers, the save the stack pointer
- * into the TCB.
- *
- * The first thing we do is save the flags then disable interrupts. This is to
- * guard our stack against having a context switch interrupt after we have already
- * pushed the registers onto the stack.
- *
- * The interrupts will have been disabled during the call to portSAVE_CONTEXT()
- * so we need not worry about reading/writing to the stack pointer.
+ * Macros to set up, restart (reload), and stop the PRT1 Timer used for
+ * the System Tick.
  */
 
 #define configTICK_RATE_HZ              (256)               /* Timer configured */
 #define configISR_ORG                   ASMPC               /* ISR relocation */
 #define configISR_IVT                   0xFFE6              /* PRT1 address */
 
-#ifdef __SCCZ80
-
 #define configSETUP_TIMER_INTERRUPT()                           \
     do{                                                         \
-        asm(                                                    \
+        __asm__(                                                \
             "EXTERN __CPU_CLOCK                             \n" \
             "EXTERN RLDR1L, RLDR1H                          \n" \
             "EXTERN TCR, TCR_TIE1, TCR_TDE1                 \n" \
@@ -85,7 +77,7 @@ extern volatile TCB_t * volatile pxCurrentTCB;
 
 #define configRESET_TIMER_INTERRUPT()                           \
     do{                                                         \
-        asm(                                                    \
+        __asm__(                                                \
             "EXTERN TCR, TMDR1L                             \n" \
             "in0 a,(TCR)                                    \n" \
             "in0 a,(TMDR1L)                                 \n" \
@@ -94,7 +86,7 @@ extern volatile TCB_t * volatile pxCurrentTCB;
 
 #define configSTOP_TIMER_INTERRUPT()                            \
     do{                                                         \
-        asm(                                                    \
+        __asm__(                                                \
             "EXTERN TCR, TCR_TIE1, TCR_TDE1                 \n" \
             "; disable down counting and interrupts for PRT1\n" \
             "in0 a,(TCR)                                    \n" \
@@ -103,55 +95,6 @@ extern volatile TCB_t * volatile pxCurrentTCB;
             );                                                  \
     }while(0)
 
-#endif
-
-#ifdef __SDCC
-
-#define configSETUP_TIMER_INTERRUPT()                           \
-    do{                                                         \
-        __asm                                                   \
-            EXTERN __CPU_CLOCK                                  \
-            EXTERN RLDR1L, RLDR1H                               \
-            EXTERN TCR, TCR_TIE1, TCR_TDE1                      \
-            ; address of ISR                                    \
-            ld de,_timer_isr                                    \
-            ld hl,configISR_IVT ; PRT1 address                  \
-            ld (hl),e                                           \
-            inc hl                                              \
-            ld (hl),d                                           \
-            ; we do configTICK_RATE_HZ ticks per second         \
-            ld hl,__CPU_CLOCK/configTICK_RATE_HZ/20-1           \
-            out0(RLDR1L),l                                      \
-            out0(RLDR1H),h                                      \
-            ; enable down counting and interrupts for PRT1      \
-            in0 a,(TCR)                                         \
-            or TCR_TIE1|TCR_TDE1                                \
-            out0 (TCR),a                                        \
-        __endasm;                                               \
-    }while(0)
-
-#define configRESET_TIMER_INTERRUPT()                           \
-    do{                                                         \
-        __asm                                                   \
-            EXTERN TCR, TMDR1L                                  \
-            ; reset interrupt for PRT1                          \
-            in0 a,(TCR)                                         \
-            in0 a,(TMDR1L)                                      \
-        __endasm;                                               \
-    }while(0)
-
-#define configSTOP_TIMER_INTERRUPT()                            \
-    do{                                                         \
-        __asm                                                   \
-            EXTERN TCR, TCR_TIE1, TCR_TDE1                      \
-            ; disable down counting and interrupts for PRT1     \
-            in0 a,(TCR)                                         \
-            xor TCR_TIE1|TCR_TDE1                               \
-            out0 (TCR),a                                        \
-        __endasm;                                               \
-    }while(0)
-
-#endif
 
 /*-----------------------------------------------------------*/
 
@@ -159,6 +102,7 @@ extern volatile TCB_t * volatile pxCurrentTCB;
  * Perform hardware setup to enable ticks from Timer.
  */
 static void prvSetupTimerInterrupt( void ) __preserves_regs(iyh,iyl);
+
 /*-----------------------------------------------------------*/
 
 /*

--- a/Z88DK/Z180/portmacro.h
+++ b/Z88DK/Z180/portmacro.h
@@ -1,5 +1,5 @@
 /*
- * FreeRTOS Kernel V10.4.3
+ * FreeRTOS Kernel V10.5.1+
  * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy of
@@ -23,6 +23,7 @@
  * https://github.com/FreeRTOS
  *
  */
+
 
 #ifndef PORTMACRO_H
 #define PORTMACRO_H
@@ -50,32 +51,42 @@
 #define portLONG                    long
 #define portSHORT                   int
 
-typedef uint16_t StackType_t;
-typedef int8_t BaseType_t;
-typedef uint8_t UBaseType_t;
+typedef uint16_t                    StackType_t;
+typedef int8_t                      BaseType_t;
+typedef uint8_t                     UBaseType_t;
 
-#if configUSE_16_BIT_TICKS == 1
-    typedef uint16_t TickType_t;
-    #define portMAX_DELAY ( TickType_t ) 0xffff
+#if configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS
+    typedef uint16_t                TickType_t;
+    #define portMAX_DELAY           ( TickType_t ) 0xffff
+#elif ( configTICK_TYPE_WIDTH_IN_BITS  == TICK_TYPE_WIDTH_32_BITS )
+    typedef uint32_t                TickType_t;
+    #define portMAX_DELAY           ( TickType_t ) 0xffffffffUL
 #else
-    typedef uint32_t TickType_t;
-    #define portMAX_DELAY ( TickType_t ) 0xffffffffUL
+    #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
 #endif
+
 /*-----------------------------------------------------------*/
 
 /* General purpose stringify macros. */
 
 #define string(a) __string(a)
 #define __string(a) #a
+
 /*-----------------------------------------------------------*/
 
-/* Critical section management using sccz80 compiler. */
+/* Architecture specifics. */
 
-#ifdef __SCCZ80
+#define portSTACK_GROWTH            ( -1 )
+#define portTICK_PERIOD_MS          ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+#define portBYTE_ALIGNMENT          1
+
+/*-----------------------------------------------------------*/
+
+/* Critical section management. */
 
 #define portENTER_CRITICAL()        \
     do{                             \
-        asm(                        \
+        __asm__(                    \
             "ld a,i             \n" \
             "di                 \n" \
             "push af            \n" \
@@ -84,7 +95,7 @@ typedef uint8_t UBaseType_t;
 
 #define portEXIT_CRITICAL()         \
     do{                             \
-        asm(                        \
+        __asm__(                    \
             "pop af             \n" \
             "; di    ; unneeded \n" \
             "jp PO,ASMPC+4      \n" \
@@ -94,32 +105,39 @@ typedef uint8_t UBaseType_t;
 
 #define portDISABLE_INTERRUPTS()    \
     do{                             \
-        asm(                        \
+        __asm__(                    \
             "di                 \n" \
             );                      \
     }while(0)
 
 #define portENABLE_INTERRUPTS()     \
     do{                             \
-        asm(                        \
+        __asm__(                    \
             "ei                 \n" \
             );                      \
     }while(0)
 
 #define portNOP()                   \
     do{                             \
-        asm(                        \
+        __asm__(                    \
             "nop                \n" \
             );                      \
     }while(0)
 
 /*
  * Macros to save all the registers, and save the stack pointer into the TCB.
+ *
+ * The first thing we do is save the flags then disable interrupts. This is to
+ * guard our stack against having a context switch interrupt after we have already
+ * pushed the registers onto the stack.
+ *
+ * The interrupts will have been disabled during the call to portSAVE_CONTEXT()
+ * so we need not worry about reading/writing to the stack pointer.
  */
 
 #define portSAVE_CONTEXT()          \
     do{                             \
-        asm(                        \
+        __asm__(                    \
             "push af            \n" \
             "ld a,i             \n" \
             "di                 \n" \
@@ -147,7 +165,7 @@ typedef uint8_t UBaseType_t;
 
 #define portRESTORE_CONTEXT()       \
     do{                             \
-        asm(                        \
+        __asm__(                    \
             "ld hl,(_pxCurrentTCB)  \n" \
             "ld e,(hl)          \n" \
             "inc hl             \n" \
@@ -176,7 +194,7 @@ typedef uint8_t UBaseType_t;
 
 #define portSAVE_CONTEXT_IN_ISR()   \
     do{                             \
-        asm(                        \
+        __asm__(                    \
             "PHASE "string(configISR_ORG)"  \n" \
             "._timer_isr_start  \n" \
             "push af            \n" \
@@ -206,7 +224,7 @@ typedef uint8_t UBaseType_t;
 
 #define portRESTORE_CONTEXT_IN_ISR()\
     do{                             \
-        asm(                        \
+        __asm__(                    \
             "ld hl,(_pxCurrentTCB)  \n" \
             "ld e,(hl)          \n" \
             "inc hl             \n" \
@@ -235,183 +253,6 @@ typedef uint8_t UBaseType_t;
             );                      \
     }while(0)
 
-#endif
-/*-----------------------------------------------------------*/
-
-/* Critical section management using sdcc compiler. */
-
-#ifdef __SDCC
-
-#define portENTER_CRITICAL()        \
-    do{                             \
-        __asm                       \
-            ld a,i                  \
-            di                      \
-            push af                 \
-        __endasm;                   \
-    }while(0)
-
-#define portEXIT_CRITICAL()         \
-    do{                             \
-        __asm                       \
-            pop af                  \
-            ; di    ; unneeded      \
-            jp PO,ASMPC+4           \
-            ei                      \
-        __endasm;                   \
-    }while(0)
-
-#define portDISABLE_INTERRUPTS()    \
-    do{                             \
-        __asm                       \
-            di                      \
-        __endasm;                   \
-    }while(0)
-
-#define portENABLE_INTERRUPTS()     \
-    do{                             \
-        __asm                       \
-            ei                      \
-        __endasm;                   \
-    }while(0)
-
-#define portNOP()                   \
-    do{                             \
-        __asm                       \
-            nop                     \
-        __endasm;                   \
-    }while(0)
-
-/*
- * Macros to save all the registers, and save the stack pointer into the TCB.
- */
-
-#define portSAVE_CONTEXT()          \
-    do{                             \
-        __asm                       \
-            push af                 \
-            ld a,i                  \
-            di                      \
-            push af ; iff1:iff2     \
-            push bc                 \
-            push de                 \
-            push hl                 \
-            exx                     \
-            ex af,af                \
-            push af                 \
-            push bc                 \
-            push de                 \
-            push hl                 \
-            push ix                 \
-            push iy                 \
-            ld hl,0                 \
-            add hl,sp               \
-            ld de,(_pxCurrentTCB)   \
-            ex de,hl                \
-            ld (hl),e               \
-            inc hl                  \
-            ld (hl),d               \
-        __endasm;                   \
-    }while(0)
-
-#define portRESTORE_CONTEXT()       \
-    do{                             \
-        __asm                       \
-            ld hl,(_pxCurrentTCB)   \
-            ld e,(hl)               \
-            inc hl                  \
-            ld d,(hl)               \
-            ex de,hl                \
-            ld sp,hl                \
-            pop iy                  \
-            pop ix                  \
-            pop hl                  \
-            pop de                  \
-            pop bc                  \
-            pop af                  \
-            ex af,af                \
-            exx                     \
-            pop hl                  \
-            pop de                  \
-            pop bc                  \
-            pop af  ; iff1:iff2     \
-            ; di    ; unneeded      \
-            jp PO,ASMPC+4           \
-            ei                      \
-            pop af                  \
-            ret                     \
-        __endasm;                   \
-    }while(0)
-
-#define portSAVE_CONTEXT_IN_ISR()   \
-    do{                             \
-        __asm                       \
-            PHASE configISR_ORG     \
-            _timer_isr_start:       \
-            push af                 \
-            ld a,0x7F               \
-            inc a   ; set PE        \
-            push af ; iff1:iff2     \
-            push bc                 \
-            push de                 \
-            push hl                 \
-            exx                     \
-            ex af,af                \
-            push af                 \
-            push bc                 \
-            push de                 \
-            push hl                 \
-            push ix                 \
-            push iy                 \
-            ld hl,0                 \
-            add hl,sp               \
-            ld de,(_pxCurrentTCB)   \
-            ex de,hl                \
-            ld (hl),e               \
-            inc hl                  \
-            ld (hl),d               \
-        __endasm;                   \
-    }while(0)
-
-#define portRESTORE_CONTEXT_IN_ISR()\
-    do{                             \
-        __asm                       \
-            ld hl,(_pxCurrentTCB)   \
-            ld e,(hl)               \
-            inc hl                  \
-            ld d,(hl)               \
-            ex de,hl                \
-            ld sp,hl                \
-            pop iy                  \
-            pop ix                  \
-            pop hl                  \
-            pop de                  \
-            pop bc                  \
-            pop af                  \
-            ex af,af                \
-            exx                     \
-            pop hl                  \
-            pop de                  \
-            pop bc                  \
-            pop af  ; iff1:iff2     \
-            ; di    ; unneeded      \
-            jp PO,ASMPC+4           \
-            ei                      \
-            pop af                  \
-            reti                    \
-            _timer_isr_end:         \
-            DEPHASE                 \
-        __endasm;                   \
-    }while(0)
-
-#endif
-/*-----------------------------------------------------------*/
-
-/* Architecture specifics. */
-
-#define portSTACK_GROWTH            ( -1 )
-#define portTICK_PERIOD_MS          ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
-#define portBYTE_ALIGNMENT          1
 /*-----------------------------------------------------------*/
 
 /* Kernel utilities. */

--- a/Z88DK/Z180/readme.md
+++ b/Z88DK/Z180/readme.md
@@ -1,12 +1,12 @@
-<h1>z180 support</h1>
+<h1>Z180 support</h1>
 
 Description
 -----------
-This PR establishes support for a Zilog z180 port, using the Programmable Reload Timer 1, configured at 256 Hz.
+This PR establishes support for a Zilog Z180 port, using the Programmable Reload Timer 1, configured at 256 Hz.
 
-Because of the generality of the z180, the address of the Interrupt Vector for PRT1 is configurable, and must be configured by the `crt0.asm` outside of this port. A configuration assumption has been made.
+Because of the generality of the Z180, the address of the Interrupt Vector for the programmable timer PRT1 is configurable, and must be configured by the `crt0.asm` outside of this port. A configuration assumption has been made, which should be checked against the actual system environment.
 
-The two compilers ([used by the z88dk](https://github.com/z88dk/z88dk)) are supported. The sccz80 compiler and the sdcc compiler. The PR is located under Z88dk.
+The two compilers ([used by the z88dk](https://github.com/z88dk/z88dk)) are supported.  The sccz80 compiler and the sdcc compiler. The in-line assembly language notation used can be read by both compilers.
 
 Background
 -----------


### PR DESCRIPTION
<!--- Title -->
Refresh to 10.5.1+ and unify inline assembly
-----------
<!--- Describe your changes in detail. -->
Updated to the 10.5.1+ System Tick resolution methods.
Unified the compiler inline assembly mnemonics to be supported by both compilers.

Test Steps
-----------
<!-- Describe the steps to reproduce. -->
Tested in [z88dk-libraries/freertos](https://github.com/feilipu/z88dk-libraries/tree/master/freertos)

Related Issue
-----------
<!-- If any, please provide issue ID. -->
No issue, just updating and general tidying.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
