### PR TITLE
Pass core ID to port lock macros

### DIFF
--- a/GCC/CORTEX_A53_64-bit_UltraScale_MPSoC/portmacro.h
+++ b/GCC/CORTEX_A53_64-bit_UltraScale_MPSoC/portmacro.h
@@ -302,17 +302,17 @@ static inline void vAssertIfInIsr()
 #define ISR_LOCK                (0u)
 #define TASK_LOCK               (1u)
 
-extern void vPortRecursiveLock(uint32_t ulLockNum, BaseType_t uxAcquire);
+extern void vPortRecursiveLock(BaseType_t xCoreID, uint32_t ulLockNum, BaseType_t uxAcquire);
 
 
-#define portRELEASE_ISR_LOCK()  vPortRecursiveLock(ISR_LOCK, pdFALSE)
-#define portGET_ISR_LOCK()      vPortRecursiveLock(ISR_LOCK, pdTRUE)
+#define portRELEASE_ISR_LOCK( xCoreID )     vPortRecursiveLock(xCoreID, ISR_LOCK, pdFALSE)
+#define portGET_ISR_LOCK( xCoreID )         vPortRecursiveLock(xCoreID, ISR_LOCK, pdTRUE)
 
-#define portRELEASE_TASK_LOCK() vPortRecursiveLock(TASK_LOCK, pdFALSE)
-#define portGET_TASK_LOCK()     vPortRecursiveLock(TASK_LOCK, pdTRUE)
+#define portRELEASE_TASK_LOCK( xCoreID )    vPortRecursiveLock(xCoreID, TASK_LOCK, pdFALSE)
+#define portGET_TASK_LOCK( xCoreID )        vPortRecursiveLock(xCoreID, TASK_LOCK, pdTRUE)
 
 extern void vInterruptCore(uint32_t ulInterruptID, uint32_t ulCoreID);
-/* Use PPI 0 as the yield core intrrupt */
+/* Use PPI 0 as the yield core interrupt. */
 #define portYIELD_CORE_INT_ID       0
 #define portYIELD_CORE( xCoreID )   vInterruptCore(portYIELD_CORE_INT_ID, (uint32_t)xCoreID)
 

--- a/GCC/CORTEX_A53_64-bit_UltraScale_MPSoC/portmacro.h
+++ b/GCC/CORTEX_A53_64-bit_UltraScale_MPSoC/portmacro.h
@@ -121,7 +121,7 @@ static inline void vEnableInterrupts()
 {
     __asm volatile (
         "msr daifclr, #2\n"
-        : 
+        :
         :
         : "memory"
     );
@@ -135,7 +135,7 @@ static inline void vRestoreInterrupts(UBaseType_t flags)
         "bic x1, x1, #128\n"
         "orr x1, x1, x2\n"
         "msr daif, x1\n"
-        : 
+        :
         : "r" (flags)
         : "x0","x1","x2","memory"
     );
@@ -145,7 +145,7 @@ static inline void vRestoreInterrupts(UBaseType_t flags)
 static inline BaseType_t xPortGetCoreID()
 {
    register BaseType_t xCoreID;
-   
+
    __asm volatile (
        "mrs  x0, mpidr_el1\n"
        "and  %0, x0, #0xff\n"
@@ -167,7 +167,7 @@ extern UBaseType_t vTaskEnterCriticalFromISR( void );
 extern void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus );
 
 #define portENTER_CRITICAL()		            vTaskEnterCritical();
-#define portEXIT_CRITICAL()			            vTaskExitCritical();    
+#define portEXIT_CRITICAL()			            vTaskExitCritical();
 #define portENTER_CRITICAL_FROM_ISR()           vTaskEnterCriticalFromISR()
 #define portEXIT_CRITICAL_FROM_ISR( x )         vTaskExitCriticalFromISR( x )
 
@@ -305,11 +305,11 @@ static inline void vAssertIfInIsr()
 extern void vPortRecursiveLock(BaseType_t xCoreID, uint32_t ulLockNum, BaseType_t uxAcquire);
 
 
-#define portRELEASE_ISR_LOCK( xCoreID )     vPortRecursiveLock(xCoreID, ISR_LOCK, pdFALSE)
-#define portGET_ISR_LOCK( xCoreID )         vPortRecursiveLock(xCoreID, ISR_LOCK, pdTRUE)
+#define portRELEASE_ISR_LOCK( xCoreID )     vPortRecursiveLock(( xCoreID ), ISR_LOCK, pdFALSE)
+#define portGET_ISR_LOCK( xCoreID )         vPortRecursiveLock(( xCoreID ), ISR_LOCK, pdTRUE)
 
-#define portRELEASE_TASK_LOCK( xCoreID )    vPortRecursiveLock(xCoreID, TASK_LOCK, pdFALSE)
-#define portGET_TASK_LOCK( xCoreID )        vPortRecursiveLock(xCoreID, TASK_LOCK, pdTRUE)
+#define portRELEASE_TASK_LOCK( xCoreID )    vPortRecursiveLock(( xCoreID ), TASK_LOCK, pdFALSE)
+#define portGET_TASK_LOCK( xCoreID )        vPortRecursiveLock(( xCoreID ), TASK_LOCK, pdTRUE)
 
 extern void vInterruptCore(uint32_t ulInterruptID, uint32_t ulCoreID);
 /* Use PPI 0 as the yield core interrupt. */

--- a/GCC/RP2350_ARM_NTZ/non_secure/portmacro.h
+++ b/GCC/RP2350_ARM_NTZ/non_secure/portmacro.h
@@ -215,10 +215,10 @@ static inline void vPortRecursiveLock( BaseType_t xCoreID,
     #define portGET_TASK_LOCK( xCoreID )
     #define portRELEASE_TASK_LOCK( xCoreID )
 #else /* configNUMBER_OF_CORES == 1 */
-    #define portGET_ISR_LOCK( xCoreID )         vPortRecursiveLock( xCoreID, 0, spin_lock_instance( configSMP_SPINLOCK_0 ), pdTRUE )
-    #define portRELEASE_ISR_LOCK( xCoreID )     vPortRecursiveLock( xCoreID, 0, spin_lock_instance( configSMP_SPINLOCK_0 ), pdFALSE )
-    #define portGET_TASK_LOCK( xCoreID )        vPortRecursiveLock( xCoreID, 1, spin_lock_instance( configSMP_SPINLOCK_1 ), pdTRUE )
-    #define portRELEASE_TASK_LOCK( xCoreID )    vPortRecursiveLock( xCoreID, 1, spin_lock_instance( configSMP_SPINLOCK_1 ), pdFALSE )
+    #define portGET_ISR_LOCK( xCoreID )         vPortRecursiveLock( ( xCoreID ), 0, spin_lock_instance( configSMP_SPINLOCK_0 ), pdTRUE )
+    #define portRELEASE_ISR_LOCK( xCoreID )     vPortRecursiveLock( ( xCoreID ), 0, spin_lock_instance( configSMP_SPINLOCK_0 ), pdFALSE )
+    #define portGET_TASK_LOCK( xCoreID )        vPortRecursiveLock( ( xCoreID ), 1, spin_lock_instance( configSMP_SPINLOCK_1 ), pdTRUE )
+    #define portRELEASE_TASK_LOCK( xCoreID )    vPortRecursiveLock( ( xCoreID ), 1, spin_lock_instance( configSMP_SPINLOCK_1 ), pdFALSE )
 #endif /* configNUMBER_OF_CORES == 1 */
 
 /* *INDENT-OFF* */

--- a/GCC/RP2350_RISC-V/include/portmacro.h
+++ b/GCC/RP2350_RISC-V/include/portmacro.h
@@ -299,10 +299,10 @@ static inline void vPortRecursiveLock( BaseType_t xCoreID,
     #define portGET_TASK_LOCK( xCoreID )
     #define portRELEASE_TASK_LOCK( xCoreID )
 #else /* configNUMBER_OF_CORES == 1 */
-    #define portGET_ISR_LOCK( xCoreID )         vPortRecursiveLock( xCoreID, 0, spin_lock_instance( configSMP_SPINLOCK_0 ), pdTRUE )
-    #define portRELEASE_ISR_LOCK( xCoreID )     vPortRecursiveLock( xCoreID, 0, spin_lock_instance( configSMP_SPINLOCK_0 ), pdFALSE )
-    #define portGET_TASK_LOCK( xCoreID )        vPortRecursiveLock( xCoreID, 1, spin_lock_instance( configSMP_SPINLOCK_1 ), pdTRUE )
-    #define portRELEASE_TASK_LOCK( xCoreID )    vPortRecursiveLock( xCoreID, 1, spin_lock_instance( configSMP_SPINLOCK_1 ), pdFALSE )
+    #define portGET_ISR_LOCK( xCoreID )         vPortRecursiveLock( ( xCoreID ), 0, spin_lock_instance( configSMP_SPINLOCK_0 ), pdTRUE )
+    #define portRELEASE_ISR_LOCK( xCoreID )     vPortRecursiveLock( ( xCoreID ), 0, spin_lock_instance( configSMP_SPINLOCK_0 ), pdFALSE )
+    #define portGET_TASK_LOCK( xCoreID )        vPortRecursiveLock( ( xCoreID ), 1, spin_lock_instance( configSMP_SPINLOCK_1 ), pdTRUE )
+    #define portRELEASE_TASK_LOCK( xCoreID )    vPortRecursiveLock( ( xCoreID ), 1, spin_lock_instance( configSMP_SPINLOCK_1 ), pdFALSE )
 #endif /* configNUMBER_OF_CORES == 1 */
 
 /* *INDENT-OFF* */

--- a/GCC/RP2350_RISC-V/include/portmacro.h
+++ b/GCC/RP2350_RISC-V/include/portmacro.h
@@ -255,7 +255,8 @@ extern void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus );
 /* Note this is a single method with uxAcquire parameter since we have
  * static vars, the method is always called with a compile time constant for
  * uxAcquire, and the compiler should do the right thing! */
-static inline void vPortRecursiveLock( uint32_t ulLockNum,
+static inline void vPortRecursiveLock( BaseType_t xCoreID,
+                                       uint32_t ulLockNum,
                                        spin_lock_t * pxSpinLock,
                                        BaseType_t uxAcquire )
 {
@@ -263,12 +264,11 @@ static inline void vPortRecursiveLock( uint32_t ulLockNum,
     static volatile uint8_t ucRecursionCountByLock[ portRTOS_SPINLOCK_COUNT ];
 
     configASSERT( ulLockNum < portRTOS_SPINLOCK_COUNT );
-    uint32_t ulCoreNum = get_core_num();
 
     if( uxAcquire )
     {
         if (!spin_try_lock_unsafe(pxSpinLock)) {
-            if( ucOwnedByCore[ ulCoreNum ][ ulLockNum ] )
+            if( ucOwnedByCore[ xCoreID ][ ulLockNum ] )
             {
                 configASSERT( ucRecursionCountByLock[ ulLockNum ] != 255u );
                 ucRecursionCountByLock[ ulLockNum ]++;
@@ -278,31 +278,31 @@ static inline void vPortRecursiveLock( uint32_t ulLockNum,
         }
         configASSERT( ucRecursionCountByLock[ ulLockNum ] == 0 );
         ucRecursionCountByLock[ ulLockNum ] = 1;
-        ucOwnedByCore[ ulCoreNum ][ ulLockNum ] = 1;
+        ucOwnedByCore[ xCoreID ][ ulLockNum ] = 1;
     }
     else
     {
-        configASSERT( ( ucOwnedByCore[ ulCoreNum ] [ulLockNum ] ) != 0 );
+        configASSERT( ( ucOwnedByCore[ xCoreID ] [ulLockNum ] ) != 0 );
         configASSERT( ucRecursionCountByLock[ ulLockNum ] != 0 );
 
         if( !--ucRecursionCountByLock[ ulLockNum ] )
         {
-            ucOwnedByCore[ ulCoreNum ] [ ulLockNum ] = 0;
+            ucOwnedByCore[ xCoreID ] [ ulLockNum ] = 0;
             spin_unlock_unsafe(pxSpinLock);
         }
     }
 }
 
 #if ( configNUMBER_OF_CORES == 1 )
-    #define portGET_ISR_LOCK()
-    #define portRELEASE_ISR_LOCK()
-    #define portGET_TASK_LOCK()
-    #define portRELEASE_TASK_LOCK()
+    #define portGET_ISR_LOCK( xCoreID )
+    #define portRELEASE_ISR_LOCK( xCoreID )
+    #define portGET_TASK_LOCK( xCoreID )
+    #define portRELEASE_TASK_LOCK( xCoreID )
 #else /* configNUMBER_OF_CORES == 1 */
-    #define portGET_ISR_LOCK()         vPortRecursiveLock( 0, spin_lock_instance( configSMP_SPINLOCK_0 ), pdTRUE )
-    #define portRELEASE_ISR_LOCK()     vPortRecursiveLock( 0, spin_lock_instance( configSMP_SPINLOCK_0 ), pdFALSE )
-    #define portGET_TASK_LOCK()        vPortRecursiveLock( 1, spin_lock_instance( configSMP_SPINLOCK_1 ), pdTRUE )
-    #define portRELEASE_TASK_LOCK()    vPortRecursiveLock( 1, spin_lock_instance( configSMP_SPINLOCK_1 ), pdFALSE )
+    #define portGET_ISR_LOCK( xCoreID )         vPortRecursiveLock( xCoreID, 0, spin_lock_instance( configSMP_SPINLOCK_0 ), pdTRUE )
+    #define portRELEASE_ISR_LOCK( xCoreID )     vPortRecursiveLock( xCoreID, 0, spin_lock_instance( configSMP_SPINLOCK_0 ), pdFALSE )
+    #define portGET_TASK_LOCK( xCoreID )        vPortRecursiveLock( xCoreID, 1, spin_lock_instance( configSMP_SPINLOCK_1 ), pdTRUE )
+    #define portRELEASE_TASK_LOCK( xCoreID )    vPortRecursiveLock( xCoreID, 1, spin_lock_instance( configSMP_SPINLOCK_1 ), pdFALSE )
 #endif /* configNUMBER_OF_CORES == 1 */
 
 /* *INDENT-OFF* */


### PR DESCRIPTION
Description
-----------
Passes the core ID as an argument to the SMP lock macros `port{GET/RELEASE}_{TASK/ISR}_LOCK` in the following ports:

- GCC/CORTEX_A53_64-bit_UltraScale_MPsoC
- GCC/RP2350_ARM_NTZ
- GCC/RP2350_RISC-V

This matches the kernel change introduced in https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1212.

Test Steps
-----------
None.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel/issues/1204

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.