### PR TITLE
Update CMakeLists.txt in RP2350 ports to fix FREERTOS_KERNEL_PATH

### DIFF
--- a/GCC/RP2350_ARM_NTZ/CMakeLists.txt
+++ b/GCC/RP2350_ARM_NTZ/CMakeLists.txt
@@ -10,7 +10,7 @@ if (NOT TARGET _FreeRTOS_kernel_inclusion_marker)
     endif()
 
     if (NOT FREERTOS_KERNEL_PATH)
-        get_filename_component(FREERTOS_KERNEL_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../.. REALPATH)
+        get_filename_component(FREERTOS_KERNEL_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../../.. REALPATH)
     endif ()
 
     message(DEBUG "FREERTOS_KERNEL_PATH is ${FREERTOS_KERNEL_PATH}")

--- a/GCC/RP2350_RISC-V/CMakeLists.txt
+++ b/GCC/RP2350_RISC-V/CMakeLists.txt
@@ -10,7 +10,7 @@ if (NOT TARGET _FreeRTOS_kernel_inclusion_marker)
     endif()
 
     if (NOT FREERTOS_KERNEL_PATH)
-        get_filename_component(FREERTOS_KERNEL_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../.. REALPATH)
+        get_filename_component(FREERTOS_KERNEL_PATH ${CMAKE_CURRENT_LIST_DIR}/../../../../.. REALPATH)
     endif ()
 
     message(DEBUG "FREERTOS_KERNEL_PATH is ${FREERTOS_KERNEL_PATH}")


### PR DESCRIPTION
## Update CMakeLists.txt in RP2350 ports to fix FREERTOS_KERNEL_PATH

## Description

The CMakeLists.txt files in the RP2350 ports attempt to derive a value for FREERTOS_KERNEL_PATH.

The existing code is based on the RP2040 port which is one level higher in the source tree directory hierarchy than the RP2350 ports.

This commit changes the derivation of FREERTOS_KERNEL_PATH to account for the additional level in the directory hierarchy.

## Test Steps

1. Create a RP2350 project
2. Clone the FreeRTOS-Kernel repository and update the FreeRTOS-Kernel-Community-Supported-Ports submodule to use the branch in this PR.
3. Add the RP2350 port directory to the CMakeLists.txt for the RP2350 project using the CMake `add_subdirectory` directive, specifying the full path to the appropriate RP2350 port directory.  Do not define FREERTOS_KERNEL_PATH manually.
4. Update an executable in the RP2350 project to depend on one of the FreeRTOS-Kernel library variants e.g. FreeRTOS-Kernel-Heap4
5. Run CMake for the RP2350 project and verify it is able to successfully locate the FreeRTOS-Kernel port and resolve the FreeRTOS-Kernel library dependancy.

## Related Issue

This PR fixes issue [#19](FreeRTOS/FreeRTOS-Kernel-Community-Supported-Ports/issues/19).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
