### PR TITLE
Fix the context array size

### DIFF
--- a/GCC/RP2350_ARM_NTZ/non_secure/portmacrocommon.h
+++ b/GCC/RP2350_ARM_NTZ/non_secure/portmacrocommon.h
@@ -232,9 +232,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * +-----------+---------------+----------+-----------------+------------------------------+-----+
  *
  * <-----------><--------------><---------><----------------><-----------------------------><---->
- *      16             16            8               8                     5                   1
+ *      16             17            8               8                     5                   1
  */
-            #define MAX_CONTEXT_SIZE    54
+            #define MAX_CONTEXT_SIZE    55
 
         #else /* #if( configENABLE_TRUSTZONE == 1 ) */
 
@@ -245,9 +245,9 @@ extern void vClearInterruptMask( uint32_t ulMask ) /* __attribute__(( naked )) P
  * +-----------+---------------+----------+-----------------+----------------------+-----+
  *
  * <-----------><--------------><---------><----------------><---------------------><---->
- *      16             16            8               8                  4              1
+ *      16             17            8               8                  4              1
  */
-            #define MAX_CONTEXT_SIZE    53
+            #define MAX_CONTEXT_SIZE    54
 
         #endif /* #if( configENABLE_TRUSTZONE == 1 ) */
 


### PR DESCRIPTION
Description
-----------
Ensure the saved context location falls within the reserved context area rather than overlapping with the next MPU_SETTINGS structure member.

This was applied to the upstream port in the following PR: https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/1230.

Test Steps
-----------
N/A.

Related Issue
-----------
https://github.com/FreeRTOS/FreeRTOS-Kernel-Community-Supported-Ports/issues/22


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
