### PR TITLE
Add portable files for RISC-V Xuantie C908 

### DIFF
--- a/GCC/RISC-V_XUANTIE_C908/LICENSE.md
+++ b/GCC/RISC-V_XUANTIE_C908/LICENSE.md
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/GCC/RISC-V_XUANTIE_C908/README.md
+++ b/GCC/RISC-V_XUANTIE_C908/README.md
@@ -1,0 +1,26 @@
+# FreeRTOS Port for XuanTie C908/C908V
+
+This directory contains the FreeRTOS port for Alibaba XuanTie C908/C908V RISC-V processors.
+
+This is the minimum configuration to boot FreeRTOS, including FPU, VPU and SMP features.
+
+For more advanced features of this CPU,
+please refer to [this page](https://www.xrvm.com/soft-tools/os/RTOS?spm=xrvm.27140568.0.0.78f19b29Tt40XI)
+and get the latest RTOS-SDK.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `port.c` | FreeRTOS port implementation
+| `cpu_task_sw.S` | Context switch assembly code |
+| `portmacro.h` | Port-specific macros and definitions |
+
+## Requirements
+- GCC:  [link](https://www.xrvm.cn/community/download?versionId=4460156621967921152)
+
+- QEMU: [link](https://www.xrvm.cn/community/download?versionId=4468398114511851520)
+
+## Building and Running
+
+- For build instructions and a complete example, please refer to the `FreeRTOS-Community-Supported-Demos/RISC-V_XUANTIE_C908_GCC/README.md`

--- a/GCC/RISC-V_XUANTIE_C908/cpu_task_sw.S
+++ b/GCC/RISC-V_XUANTIE_C908/cpu_task_sw.S
@@ -1,0 +1,488 @@
+ /*
+ * Copyright (C) 2017-2024 Alibaba Group Holding Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <riscv_csr.h>
+#include <FreeRTOSConfig.h>
+
+.global cpu_is_irq_enable
+.global cpu_intrpt_save
+.global cpu_intrpt_restore
+.global vPortStartTask
+.global MachineSoftwareIRQ_Handler
+
+#if configNUMBER_OF_CORES > 1
+.extern pxCurrentTCBs
+#else
+.extern pxCurrentTCB
+#endif
+.extern vTaskSwitchContext
+.extern g_top_irqstack
+
+.equ RISCV_MSTATUS_MIE,        (1<<3)       /*machine-level interrupt bit*/
+.equ RISCV_SSTATUS_SIE,        (1<<1)       /*supervisor-level interrupt bit*/
+
+.type   cpu_intrpt_save, %function
+cpu_intrpt_save:
+    csrrci a0, MODE_PREFIX(status), RISCV_MSTATUS_MIE
+    ret
+    .size   cpu_intrpt_save, . - cpu_intrpt_save
+
+.type   cpu_is_irq_enable, %function
+cpu_is_irq_enable:
+    csrr a0, MODE_PREFIX(status)
+    andi a0, a0, RISCV_MSTATUS_MIE
+    ret
+    .size   cpu_is_irq_enable, . - cpu_is_irq_enable
+
+.type   cpu_intrpt_restore, %function
+cpu_intrpt_restore:
+    csrw MODE_PREFIX(status), a0
+    ret
+    .size   cpu_intrpt_restore, . - cpu_intrpt_restore
+
+.macro FREERTOS_RESTORE_MSTATUS
+    li       t1, 0
+
+    #ifdef CONFIG_RISC_VECTOR_ENABLED
+        csrr     t0, vlenb
+        slli     t0, t0, 5
+        add      t1, t1, t0
+        addi     t1, t1, 40
+    #endif  /* CONFIG_RISC_VECTOR_ENABLED */
+
+    #if CONFIG_RISCV_FPU_ENABLED
+        addi     t1, t1, (256 + 8)
+    #endif /* CONFIG_RISCV_FPU_ENABLED */
+
+    addi     t1, t1, (256 - 8)
+    add      t1, sp, t1
+    ld       t3, (0)(t1)
+    csrw     mstatus, t3
+.endm
+
+/********************************************************************
+ * Functions: vPortYield
+ *
+ ********************************************************************/
+.global vPortYield
+.type   vPortYield, %function
+vPortYield:
+    /* push regs */
+    addi    sp, sp, -16
+    sd      t0, 0(sp)
+    sd      t2, 8(sp)
+    /*trigger irq*/
+    csrr    t2, mhartid
+    slli    t2, t2, 2
+    li      t0, CLINT_BASE
+    add     t0, t0, t2
+    li      t2, 0x1
+    sw      t2, 0(t0)
+    /* pop regs */
+    ld      t0, 0(sp)
+    ld      t2, 8(sp)
+    addi    sp, sp, 16
+    ret
+
+.align 8
+vPortStartTask:
+    j       __vPortFirstTask
+
+.align 8
+MachineSoftwareIRQ_Handler:
+    addi    sp, sp, -(128+128)
+    sd      x1,  (0  +0  )(sp)
+    sd      x3,  (4  +4  )(sp)
+    sd      x4,  (8  +8  )(sp)
+    sd      x5,  (12 +12 )(sp)
+    sd      x6,  (16 +16 )(sp)
+    sd      x7,  (20 +20 )(sp)
+    sd      x8,  (24 +24 )(sp)
+    sd      x9,  (28 +28 )(sp)
+    sd      x10, (32 +32 )(sp)
+    sd      x11, (36 +36 )(sp)
+    sd      x12, (40 +40 )(sp)
+    sd      x13, (44 +44 )(sp)
+    sd      x14, (48 +48 )(sp)
+    sd      x15, (52 +52 )(sp)
+    sd      x16, (56 +56 )(sp)
+    sd      x17, (60 +60 )(sp)
+    sd      x18, (64 +64 )(sp)
+    sd      x19, (68 +68 )(sp)
+    sd      x20, (72 +72 )(sp)
+    sd      x21, (76 +76 )(sp)
+    sd      x22, (80 +80 )(sp)
+    sd      x23, (84 +84 )(sp)
+    sd      x24, (88 +88 )(sp)
+    sd      x25, (92 +92 )(sp)
+    sd      x26, (96 +96 )(sp)
+    sd      x27, (100+100)(sp)
+    sd      x28, (104+104)(sp)
+    sd      x29, (108+108)(sp)
+    sd      x30, (112+112)(sp)
+    sd      x31, (116+116)(sp)
+
+    csrr    t0, MODE_PREFIX(epc)
+    sd      t0, (120+120)(sp)
+    csrr    t3, MODE_PREFIX(status)
+    sd      t3, (124+124)(sp)
+
+    #if CONFIG_RISCV_FPU_ENABLED
+        li       t1, SR_FS_DIRTY
+        and      t4, t3, t1
+        bne      t4, t1, 1f
+
+        addi     sp, sp, -(4+4)
+        frcsr    t0
+        sd       t0, (0  +0  )(sp)
+
+        addi     sp, sp, -(128+128)
+        fsd      f31, (0  +0  )(sp)
+        fsd      f30, (4  +4  )(sp)
+        fsd      f29, (8  +8  )(sp)
+        fsd      f28, (12 +12 )(sp)
+        fsd      f27, (16 +16 )(sp)
+        fsd      f26, (20 +20 )(sp)
+        fsd      f25, (24 +24 )(sp)
+        fsd      f24, (28 +28 )(sp)
+        fsd      f23, (32 +32 )(sp)
+        fsd      f22, (36 +36 )(sp)
+        fsd      f21, (40 +40 )(sp)
+        fsd      f20, (44 +44 )(sp)
+        fsd      f19, (48 +48 )(sp)
+        fsd      f18, (52 +52 )(sp)
+        fsd      f17, (56 +56 )(sp)
+        fsd      f16, (60 +60 )(sp)
+        fsd      f15, (64 +64 )(sp)
+        fsd      f14, (68 +68 )(sp)
+        fsd      f13, (72 +72 )(sp)
+        fsd      f12, (76 +76 )(sp)
+        fsd      f11, (80 +80 )(sp)
+        fsd      f10, (84 +84 )(sp)
+        fsd      f9,  (88 +88 )(sp)
+        fsd      f8,  (92 +92 )(sp)
+        fsd      f7,  (96 +96 )(sp)
+        fsd      f6,  (100+100)(sp)
+        fsd      f5,  (104+104)(sp)
+        fsd      f4,  (108+108)(sp)
+        fsd      f3,  (112+112)(sp)
+        fsd      f2,  (116+116)(sp)
+        fsd      f1,  (120+120)(sp)
+        fsd      f0,  (124+124)(sp)
+
+        j        2f
+        1:
+            addi     sp, sp, -264
+        2:
+    #endif /* CONFIG_RISCV_VECTOR_ENABLED */
+
+    #if CONFIG_RISCV_VECTOR_ENABLED
+        li      t1, SR_VS_DIRTY
+        and     t4, t3, t1
+        bne     t4, t1, 3f
+        addi    sp, sp, -(20+20)
+        csrr    t0, vl
+        sd      t0,  (0  +0  )(sp)
+        csrr    t0, vtype
+        sd      t0,  (4  +4  )(sp)
+        csrr    t0, vstart
+        sd      t0,  (8  +8  )(sp)
+        csrr    t0, vxsat
+        sd      t0,  (12 +12 )(sp)
+        csrr    t0, vxrm
+        sd      t0,  (16 +16 )(sp)
+
+        csrr     t0, vlenb
+        slli     t0, t0, 3
+        slli     t1, t0, 2
+        sub      sp, sp, t1
+        #if (__riscv_v == 7000)
+            vsetvli  zero, zero, e8, m8
+            vsb.v    v0, (sp)
+            add      sp, sp, t0
+            vsb.v    v8, (sp)
+            add      sp, sp, t0
+            vsb.v    v16, (sp)
+            add      sp, sp, t0
+            vsb.v    v24, (sp)
+        #elif (__riscv_v == 1000000)
+            vsetvli  zero, zero, e8, m8, ta, ma
+            vs8r.v   v0, (sp)
+            add      sp, sp, t0
+            vs8r.v   v8, (sp)
+            add      sp, sp, t0
+            vs8r.v   v16, (sp)
+            add      sp, sp, t0
+            vs8r.v   v24, (sp)
+        #endif
+        sub      t0, t1, t0
+        sub      sp, sp, t0
+
+        j        4f
+        3:
+        addi     sp, sp, -40
+        csrr     t0, vlenb
+        slli     t0, t0, 5
+        sub      sp, sp, t0
+        4:
+    #endif /*CONFIG_RISCV_VECTOR_ENABLED */
+
+    #if configNUMBER_OF_CORES > 1
+        la       a1, pxCurrentTCBs
+        csrr     a0, mhartid
+
+        li       t1, (__riscv_xlen / 8)
+        mul      t0, a0, t1
+        add      a1, a1, t0
+        ld       a1, (a1)
+        sd       sp, (a1)
+
+        jal      xPortTaskSwitch
+    #else
+        la      a1, pxCurrentTCB
+        ld      a1, (a1)
+        sd      sp, (a1)
+
+        jal     vTaskSwitchContext
+    #endif /* configNUMBER_OF_CORES > 1 */
+
+    __vPortFirstTask:
+    #if configNUMBER_OF_CORES > 1
+        la      a1, pxCurrentTCBs
+        csrr    t0, mhartid
+        li      t1, (__riscv_xlen / 8)
+        mul     t0, t0, t1
+        add     a1, a1, t0
+    #else  /* configNUMBER_OF_CORES > 1 */
+        la      a1, pxCurrentTCB
+    #endif   /* configNUMBER_OF_CORES > 1 */
+    ld      a1, (a1)
+    ld      sp, (a1)
+
+    FREERTOS_RESTORE_MSTATUS
+
+    /* when using SMP, pending bit shoudn't be cleared here */
+    #if configNUMBER_OF_CORES == 1
+        /*clear software interrupt*/
+        li      t0, CLINT_BASE
+        csrr    t2, mhartid
+        slli    t2, t2, 2
+        add     t0, t0, t2
+        li      t2, 0x0
+        sw      t2, 0(t0)
+    #endif
+
+    #if CONFIG_RISCV_VECTOR_ENABLED
+        li       t1, SR_VS_DIRTY
+        and      t4, t3, t1
+        bne      t4, t1, 13f
+
+        csrr     t0, vlenb
+        slli     t0, t0, 3
+        #if (__riscv_v == 7000)
+            vsetvli  zero, zero, e8, m8
+            vlb.v    v0, (sp)
+            add      sp, sp, t0
+            vlb.v    v8, (sp)
+            add      sp, sp, t0
+            vlb.v    v16, (sp)
+            add      sp, sp, t0
+            vlb.v    v24, (sp)
+            add      sp, sp, t0
+        #elif (__riscv_v == 1000000)
+            vsetvli  zero, zero, e8, m8, ta, ma
+            vl8r.v   v0, (sp)
+            add      sp, sp, t0
+            vl8r.v   v8, (sp)
+            add      sp, sp, t0
+            vl8r.v   v16, (sp)
+            add      sp, sp, t0
+            vl8r.v   v24, (sp)
+            add      sp, sp, t0
+        #endif
+        lwu     t0, (0 +0)(sp)
+        lwu     t1, (4 +4)(sp)
+        lwu     t2, (8 +8)(sp)
+        vsetvl  zero, t0, t1
+        csrw    vstart, t2
+        lwu     t2, (12 +12)(sp)
+        csrw    vxsat, t2
+        lwu     t2, (16 +16)(sp)
+        csrw    vxrm, t2
+        addi    sp, sp, (20+20)
+        j       14f
+        13:
+            /* don't restore, move sp only */
+            addi    sp, sp, (20+20)
+            csrr    t0, vlenb
+            slli    t0, t0, 5
+            add     sp, sp, t0
+        14:
+    #endif /* CONFIG_RISCV_VECTOR_ENABLED */
+
+    #ifdef CONFIG_RISCV_FPU_ENABLED
+        li       t1, SR_FS_DIRTY
+        and      t4, t3, t1
+        bne      t4, t1, 15f
+        fld      f31,( 0 + 0 )(sp)
+        fld      f30,( 4 + 4 )(sp)
+        fld      f29,( 8 + 8 )(sp)
+        fld      f28,( 12+ 12)(sp)
+        fld      f27,( 16+ 16)(sp)
+        fld      f26,( 20+ 20)(sp)
+        fld      f25,( 24+ 24)(sp)
+        fld      f24,( 28+ 28)(sp)
+        fld      f23,( 32+ 32)(sp)
+        fld      f22,( 36+ 36)(sp)
+        fld      f21,( 40+ 40)(sp)
+        fld      f20,( 44+ 44)(sp)
+        fld      f19,( 48+ 48)(sp)
+        fld      f18,( 52+ 52)(sp)
+        fld      f17,( 56+ 56)(sp)
+        fld      f16,( 60+ 60)(sp)
+        fld      f15,( 64+ 64)(sp)
+        fld      f14,( 68+ 68)(sp)
+        fld      f13,( 72+ 72)(sp)
+        fld      f12,( 76+ 76)(sp)
+        fld      f11,( 80+ 80)(sp)
+        fld      f10,( 84+ 84)(sp)
+        fld      f9, ( 88+ 88)(sp)
+        fld      f8, ( 92+ 92)(sp)
+        fld      f7, ( 96+ 96)(sp)
+        fld      f6, (100+100)(sp)
+        fld      f5, (104+104)(sp)
+        fld      f4, (108+108)(sp)
+        fld      f3, (112+112)(sp)
+        fld      f2, (116+116)(sp)
+        fld      f1, (120+120)(sp)
+        fld      f0, (124+124)(sp)
+        addi     sp, sp, (128+128)
+
+        ld       t0, (0 +0)(sp)
+        fscsr    t0
+        addi     sp, sp, (4+4)
+
+        j        16f
+        15:
+            addi     sp, sp, 264
+        16:
+    #endif
+
+    ld      t0, (120 +120)(sp)
+    csrw    MODE_PREFIX(epc), t0
+
+    ld     x1,  (0  +0  )(sp)
+    ld     x3,  (4  +4  )(sp)
+    ld     x4,  (8  +8  )(sp)
+    ld     x5,  (12 +12 )(sp)
+    ld     x6,  (16 +16 )(sp)
+    ld     x7,  (20 +20 )(sp)
+    ld     x8,  (24 +24 )(sp)
+    ld     x9,  (28 +28 )(sp)
+    ld     x10, (32 +32 )(sp)
+    ld     x11, (36 +36 )(sp)
+    ld     x12, (40 +40 )(sp)
+    ld     x13, (44 +44 )(sp)
+    ld     x14, (48 +48 )(sp)
+    ld     x15, (52 +52 )(sp)
+    ld     x16, (56 +56 )(sp)
+    ld     x17, (60 +60 )(sp)
+    ld     x18, (64 +64 )(sp)
+    ld     x19, (68 +68 )(sp)
+    ld     x20, (72 +72 )(sp)
+    ld     x21, (76 +76 )(sp)
+    ld     x22, (80 +80 )(sp)
+    ld     x23, (84 +84 )(sp)
+    ld     x24, (88 +88 )(sp)
+    ld     x25, (92 +92 )(sp)
+    ld     x26, (96 +96 )(sp)
+    ld     x27, (100+100)(sp)
+    ld     x28, (104+104)(sp)
+    ld     x29, (108+108)(sp)
+    ld     x30, (112+112)(sp)
+    ld     x31, (116+116)(sp)
+    addi    sp, sp, (128+128)
+
+    MODE_PREFIX(ret)
+
+   .size   MachineSoftwareIRQ_Handler, . - MachineSoftwareIRQ_Handler
+/*-----------------------------------------------------------*/
+
+/*
+ * Unlike other ports pxPortInitialiseStack() is written in assembly code as it
+ * needs access to the portasmADDITIONAL_CONTEXT_SIZE constant.  The prototype
+ * for the function is as per the other ports:
+ * StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters );
+ *
+ * As per the standard RISC-V ABI pxTopcOfStack is passed in in a0, pxCode in
+ * a1, and pvParameters in a2.  The new top of stack is passed out in a0.
+ *
+ * RISC-V maps registers to ABI names as follows (X1 to X31 integer registers
+ * for the 'I' profile, X1 to X15 for the 'E' profile, currently I assumed).
+ *
+ * Register		ABI Name	Description						Saver
+ * x0			zero		Hard-wired zero					-
+ * x1			ra			Return address					Caller
+ * x2			sp			Stack pointer					Callee
+ * x3			gp			Global pointer					-
+ * x4			tp			Thread pointer					-
+ * x5-7			t0-2		Temporaries						Caller
+ * x8			s0/fp		Saved register/Frame pointer	Callee
+ * x9			s1			Saved register					Callee
+ * x10-11		a0-1		Function Arguments/return values Caller
+ * x12-17		a2-7		Function arguments				Caller
+ * x18-27		s2-11		Saved registers					Callee
+ * x28-31		t3-6		Temporaries						Caller
+ *
+ * The RISC-V context is saved t FreeRTOS tasks in the following stack frame,
+ * where the global and thread pointers are currently assumed to be constant so
+ * are not saved:
+ *
+ * mstatus
+ * x31
+ * x30
+ * x29
+ * x28
+ * x27
+ * x26
+ * x25
+ * x24
+ * x23
+ * x22
+ * x21
+ * x20
+ * x19
+ * x18
+ * x17
+ * x16
+ * x15
+ * x14
+ * x13
+ * x12
+ * x11
+ * pvParameters
+ * x9
+ * x8
+ * x7
+ * x6
+ * x5
+ * portTASK_RETURN_ADDRESS
+ * [chip specific registers go here]
+ * pxCode
+ */
+
+/*-----------------------------------------------------------*/

--- a/GCC/RISC-V_XUANTIE_C908/port.c
+++ b/GCC/RISC-V_XUANTIE_C908/port.c
@@ -1,0 +1,400 @@
+ /*
+ * Copyright (C) 2017-2024 Alibaba Group Holding Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Scheduler includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+#include "portmacro.h"
+#include "string.h"
+
+typedef enum {
+    CORE_0 = 0,
+    CORE_1,
+    CORE_2,
+    CORE_3,
+    CORE_4,
+    CORE_5,
+    CORE_6,
+    CORE_7
+} CoreID;
+
+#define printk printf
+
+extern void vPortStartTask(void);
+
+#if configNUMBER_OF_CORES > 1
+
+    void atomic_store(spin_lock_t *ptr, spin_lock_t val)
+    {
+        spin_lock_t result = 0;
+        asm volatile ("amoswap.w.aqrl %0, %1, (%2)" : "=r"(result) : "r"(val), "r"(ptr) : "memory");
+    }
+
+    spin_lock_t atomic_exchange(spin_lock_t* ptr, spin_lock_t val)
+    {
+        spin_lock_t result = 0;
+        asm volatile ("amoswap.w.aqrl %0, %1, (%2)" : "=r"(result) : "r"(val), "r"(ptr) : "memory");
+        return result;
+    }
+
+    static inline int spinlock_trylock(spin_lock_t *lock)
+    {
+        spin_lock_t oldval;
+
+        oldval = atomic_exchange(lock, 1);
+
+        return oldval == 0 ? 1 : 0;
+    }
+
+    static inline void spinlock_lock(spin_lock_t *lock)
+    {
+        while(atomic_exchange(lock, 1) != 0) {
+        }
+    }
+
+    static inline void spinlock_unlock(spin_lock_t *lock)
+    {
+        atomic_store(lock, 0);
+    }
+
+    UBaseType_t uxCriticalNestings[configNUMBER_OF_CORES] = {0};
+    spin_lock_t hw_sync_locks[portRTOS_SPINLOCK_COUNT] = {0};
+
+#endif
+/*-----------------------------------------------------------*/
+
+/* Used to keep track of the number of nested calls to taskENTER_CRITICAL().  This
+will be set to 0 prior to the first task being started. */
+portLONG ulCriticalNesting = 0x9999UL;
+
+/* Used to record one tack want to swtich task after enter critical area, we need know it
+ * and implement task switch after exit critical area */
+portLONG pendsvflag = 0;
+
+#if( portHAS_STACK_OVERFLOW_CHECKING == 1 )
+StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, StackType_t *pxEndOfStack, TaskFunction_t pxCode, void *pvParameters )
+#else
+StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t pxCode, void *pvParameters )
+#endif
+{
+    extern int __global_pointer$;
+    StackType_t *stk  = NULL;
+    StackType_t temp = (StackType_t)pxTopOfStack;
+    unsigned long status = SR_MPP_M | SR_MPIE;
+
+    #ifdef ( CONFIG_RISCV_VECTOR_ENABLED )
+    {
+        int vlenb = csi_vlenb_get_value();
+        status |= SR_VS_INITIAL;
+    }
+    #endif
+
+    #ifdef ( CONFIG_RISCV_FPU_ENABLED )
+    {
+        status |= SR_FS_INITIAL;
+    }
+    #endif
+
+    temp &= 0xFFFFFFFFFFFFFFF8UL;
+    stk = (StackType_t *)temp;
+
+    /* FS=0b01 MPP=0b11 MPIE=0b1 */
+    *(--stk)  = (uint64_t)status;                    /* status */
+    *(--stk)  = (uint64_t)pxCode;                    /* Entry Point */
+
+    *(--stk)  = (uint64_t)0x3131313131313131L;       /* X31         */
+    *(--stk)  = (uint64_t)0x3030303030303030L;       /* X30         */
+    *(--stk)  = (uint64_t)0x2929292929292929L;       /* X29         */
+    *(--stk)  = (uint64_t)0x2828282828282828L;       /* X28         */
+    *(--stk)  = (uint64_t)0x2727272727272727L;       /* X27         */
+    *(--stk)  = (uint64_t)0x2626262626262626L;       /* X26         */
+    *(--stk)  = (uint64_t)0x2525252525252525L;       /* X25         */
+    *(--stk)  = (uint64_t)0x2424242424242424L;       /* X24         */
+    *(--stk)  = (uint64_t)0x2323232323232323L;       /* X23         */
+    *(--stk)  = (uint64_t)0x2222222222222222L;       /* X22         */
+    *(--stk)  = (uint64_t)0x2121212121212121L;       /* X21         */
+    *(--stk)  = (uint64_t)0x2020202020202020L;       /* X20         */
+    *(--stk)  = (uint64_t)0x1919191919191919L;       /* X19         */
+    *(--stk)  = (uint64_t)0x1818181818181818L;       /* X18         */
+    *(--stk)  = (uint64_t)0x1717171717171717L;       /* X17         */
+    *(--stk)  = (uint64_t)0x1616161616161616L;       /* X16         */
+    *(--stk)  = (uint64_t)0x1515151515151515L;       /* X15         */
+    *(--stk)  = (uint64_t)0x1414141414141414L;       /* X14         */
+    *(--stk)  = (uint64_t)0x1313131313131313L;       /* X13         */
+    *(--stk)  = (uint64_t)0x1212121212121212L;       /* X12         */
+    *(--stk)  = (uint64_t)0x1111111111111111L;       /* X11         */
+    *(--stk)  = (uint64_t)pvParameters;              /* X10         */
+    *(--stk)  = (uint64_t)0x0909090909090909L;       /* X9          */
+    *(--stk)  = (uint64_t)pxTopOfStack;              /* X8, aka. fp */
+    *(--stk)  = (uint64_t)0x0707070707070707L;       /* X7          */
+    *(--stk)  = (uint64_t)0x0606060606060606L;       /* X6          */
+    *(--stk)  = (uint64_t)0x0505050505050505L;       /* X5          */
+    *(--stk)  = (uint64_t)0x0404040404040404L;       /* X4          */
+    *(--stk)  = (uint64_t)&__global_pointer$;        /* X3          */
+    *(--stk)  = (uint64_t)vTaskDelete;       /* X1          */
+    #if ( CONFIG_RISCV_FPU_ENABLED )
+    {
+        *(--stk)  = (uint64_t)0x0L;                  /* FCSR        */
+
+        int num = __riscv_flen / 8 * 32 / sizeof(StackType_t);
+        for (int i = 0; i < num; i++) {
+            *(--stk)  = (StackType_t)0x1234567812345678L;    /* F31 ~ F0    */
+        }
+    }
+    #endif
+
+    #if ( CONFIG_RISCV_VECTOR_ENABLED )
+    {
+        *(--stk)  = (uint64_t)0x0L;                  /* VXRM        */
+        *(--stk)  = (uint64_t)0x0L;                  /* VXSAT       */
+        *(--stk)  = (uint64_t)0x0L;                  /* VSTART      */
+        *(--stk)  = (uint64_t)0x0L;                  /* VTYPE       */
+        *(--stk)  = (uint64_t)0x0L;                  /* VL          */
+
+        int num = vlenb * 32 / sizeof(StackType_t);
+        for (int i = 0; i < num; i++) {
+            *(--stk)  = (StackType_t)0x1234567812345678L;    /* V31 ~ V0    */
+        }
+    }
+    #endif
+
+    #if( portHAS_STACK_OVERFLOW_CHECKING == 1 )
+    {
+        if (stk <= pxEndOfStack)
+        {
+            printf("pxTopOfStack: %p, pxEndOfStack: %p, stk: %p\r\n", pxTopOfStack, pxEndOfStack, stk);
+            configASSERT(pdFALSE);
+            return NULL;
+        }
+    }
+    #endif
+
+    return stk;
+}
+
+#if ( configNUMBER_OF_CORES > 1 )
+    static void prvTaskExitError(void)
+    {
+        volatile uint32_t ulDummy = 0;
+
+        /* A function that implements a task must not exit or attempt to return to
+        its caller as there is nothing to return to.  If a task wants to exit it
+        should instead call vTaskDelete( NULL ).
+
+        Artificially force an assert() to be triggered if configASSERT() is
+        defined, then stop here so application writers can catch the error. */
+        configASSERT(ulCriticalNesting == ~0UL);
+        portDISABLE_INTERRUPTS();
+        while (ulDummy == 0) {
+            /* This file calls prvTaskExitError() after the scheduler has been
+            started to remove a compiler warning about the function being defined
+            but never called.  ulDummy is used purely to quieten other warnings
+            about code appearing after this function is called - making ulDummy
+            volatile makes the compiler think the function could return and
+            therefore not output an 'unreachable code' warning for code that appears
+            after it. */
+            /* Sleep and wait for interrupt */
+            __WFI();
+        }
+    }
+
+    static volatile unsigned long ulSchedulerReady = 0;
+    BaseType_t xPortStartScheduler(void)
+    {
+        portDISABLE_INTERRUPTS();
+
+        BaseType_t xCoreID = portGET_CORE_ID();
+        if (xCoreID == CORE_0) {
+            ulSchedulerReady = 1;
+        } else {
+            // other cores wait for scheduler ready signal
+            while (ulSchedulerReady == 0);
+        }
+
+        /* Initialise the critical nesting count ready for the first task. */
+        portSET_CRITICAL_NESTING_COUNT(xCoreID, 0);
+
+        /* Start the first task. */
+        vPortStartTask();
+
+        /* Should never get here as the tasks will now be executing!  Call the task
+        exit error function to prevent compiler warnings about a static function
+        not being called in the case that the application writer overrides this
+        functionality by defining configTASK_RETURN_ADDRESS.  Call
+        vTaskSwitchContext() so link time optimisation does not remove the
+        symbol. */
+        vTaskSwitchContext(xCoreID);
+        prvTaskExitError();
+
+        /* Should not get here! */
+        return 0;
+    }
+
+    extern BaseType_t secondary_boot_flag;
+    void SecondaryCoresUp(void)
+    {
+        extern void riscv_soc_start_cpu(int cpu_num);
+        for (int i = 1; i < configNUMBER_OF_CORES; i++) {
+            riscv_soc_start_cpu(i);
+        }
+        mb();
+        secondary_boot_flag = 0xa55a;
+    }
+
+    void xPortTaskSwitch(long cpuid)
+    {
+        /* Clear software IRQ Pending bit */
+        clear_software_irq( cpuid );
+        vTaskSwitchContext( cpuid );
+    }
+#else /* configNUMBER_OF_CORES > 1 */
+    BaseType_t xPortStartScheduler( void )
+    {
+        ulCriticalNesting = 0UL;
+
+        vPortStartTask();
+
+        return pdFALSE;
+    }
+#endif /* configNUMBER_OF_CORES > 1 */
+
+void vPortEndScheduler( void )
+{
+    /* Not implemented. */
+    for( ;; );
+}
+
+#if configNUMBER_OF_CORES > 1
+    /* Note this is a single method with uxAcquire parameter since we have
+    * static vars, the method is always called with a compile time constant for
+    * uxAcquire, and the compiler should do the right thing! */
+    void vPortRecursiveLock(unsigned long ulCoreNum, unsigned long ulLockNum, spin_lock_t *pxSpinLock, BaseType_t uxAcquire)
+    {
+        // can only control the lock pxSpinLock, don't use this function to control any other lock.
+        static volatile uint8_t ucOwnedByCore[ configNUMBER_OF_CORES ][portRTOS_SPINLOCK_COUNT];
+        static volatile uint8_t ucRecursionCountByLock[ portRTOS_SPINLOCK_COUNT ];
+
+        configASSERT(ulLockNum < portRTOS_SPINLOCK_COUNT);
+
+        if (uxAcquire) {
+            if (!spinlock_trylock(pxSpinLock)) {
+                if( ucOwnedByCore[ ulCoreNum ][ ulLockNum ] )
+                {
+                    configASSERT( ucRecursionCountByLock[ ulLockNum ] != 255u );
+                    ucRecursionCountByLock[ ulLockNum ]++;
+                    return;
+                }
+                spinlock_lock(pxSpinLock);
+            }
+
+            configASSERT( ucRecursionCountByLock[ ulLockNum ] == 0 );
+            ucRecursionCountByLock[ ulLockNum ] = 1;
+            ucOwnedByCore[ ulCoreNum ][ ulLockNum ] = 1;
+        } else {
+            configASSERT( ( ucOwnedByCore[ ulCoreNum ] [ulLockNum ] ) != 0 );
+            configASSERT( ucRecursionCountByLock[ ulLockNum ] != 0 );
+
+            if( !--ucRecursionCountByLock[ ulLockNum ] )
+            {
+                ucOwnedByCore[ ulCoreNum ] [ ulLockNum ] = 0;
+                spinlock_unlock(pxSpinLock);
+            }
+        }
+    }
+
+#else  /* configNUMBER_OF_CORES > 1 */
+
+    void vPortEnterCritical( void )
+    {
+        portDISABLE_INTERRUPTS();
+        ulCriticalNesting ++;
+    }
+
+    void vPortExitCritical( void )
+    {
+        if (ulCriticalNesting == 0) {
+            while(1);
+        }
+
+        ulCriticalNesting --;
+        if (ulCriticalNesting == 0) {
+            portENABLE_INTERRUPTS();
+
+            if (pendsvflag) {
+                pendsvflag = 0;
+                portYIELD();
+            }
+        }
+    }
+#endif /* configNUMBER_OF_CORES > 1 */
+
+void xPortSysTickHandler( void )
+{
+    UBaseType_t ulPreviousMask;
+    /* Tasks or ISRs running on other cores may still in critical section in
+    * multiple cores environment. Incrementing tick needs to performed in
+    * critical section. */
+    ulPreviousMask = taskENTER_CRITICAL_FROM_ISR();
+    {
+        /* Increment the RTOS tick. */
+        if (xTaskIncrementTick() != pdFALSE) {
+            /* A context switch is required.  Context switching is performed in
+            the SWI interrupt.  Pend the SWI interrupt. */
+            portYIELD();
+        }
+    }
+    taskEXIT_CRITICAL_FROM_ISR( ulPreviousMask );
+}
+
+
+#if configNUMBER_OF_CORES > 1
+    void clear_software_irq(int xCoreID)
+    {
+        *(uint32_t*)((uintptr_t)CLINT_BASE + ((xCoreID) << 2)) = 0x0;
+        mb();
+    }
+
+    void vPortYield_Core(int xCoreID)
+    {
+        *(uint32_t*)((uintptr_t)CLINT_BASE + ((xCoreID) << 2)) = 0x1;
+        mb();
+    }
+#endif /* configNUMBER_OF_CORES > 1 */
+
+void vPortEnableInterrupt( void )
+{
+    __enable_irq();
+}
+
+void vPortDisableInterrupt( void )
+{
+    __disable_irq();
+}
+
+
+__attribute__((weak)) void vApplicationStackOverflowHook( TaskHandle_t pxTask, char *pcTaskName )
+{
+    void *pxTopOfStack = (void *)(*(unsigned long *)pxTask);
+    printf("!!! task [%s] stack overflow. pxTop: %p\r\n", pcTaskName, pxTopOfStack);
+    for(;;);
+}
+
+__attribute__((weak)) void vApplicationMallocFailedHook( void )
+{
+    for(;;);
+}

--- a/GCC/RISC-V_XUANTIE_C908/port.c
+++ b/GCC/RISC-V_XUANTIE_C908/port.c
@@ -97,14 +97,13 @@ StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t px
     StackType_t temp = (StackType_t)pxTopOfStack;
     unsigned long status = SR_MPP_M | SR_MPIE;
 
-    #ifdef ( CONFIG_RISCV_VECTOR_ENABLED )
+    #if ( CONFIG_RISCV_VECTOR_ENABLED )
     {
-        int vlenb = csi_vlenb_get_value();
         status |= SR_VS_INITIAL;
     }
     #endif
 
-    #ifdef ( CONFIG_RISCV_FPU_ENABLED )
+    #if ( CONFIG_RISCV_FPU_ENABLED )
     {
         status |= SR_FS_INITIAL;
     }
@@ -165,7 +164,7 @@ StackType_t *pxPortInitialiseStack( StackType_t *pxTopOfStack, TaskFunction_t px
         *(--stk)  = (uint64_t)0x0L;                  /* VSTART      */
         *(--stk)  = (uint64_t)0x0L;                  /* VTYPE       */
         *(--stk)  = (uint64_t)0x0L;                  /* VL          */
-
+        int vlenb = csi_vlenb_get_value();
         int num = vlenb * 32 / sizeof(StackType_t);
         for (int i = 0; i < num; i++) {
             *(--stk)  = (StackType_t)0x1234567812345678L;    /* V31 ~ V0    */

--- a/GCC/RISC-V_XUANTIE_C908/portmacro.h
+++ b/GCC/RISC-V_XUANTIE_C908/portmacro.h
@@ -1,0 +1,174 @@
+ /*
+ * Copyright (C) 2017-2024 Alibaba Group Holding Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PORTMACRO_H
+#define PORTMACRO_H
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <drv/tick.h>
+#include <drv/irq.h>
+#include <riscv_csr.h>
+
+#ifdef __cplusplus
+    extern "C" {
+#endif
+
+#define portCHAR                char
+#define portFLOAT               float
+#define portDOUBLE              double
+#define portLONG                long
+#define portSHORT               short
+#define portSTACK_TYPE          uint64_t
+#define portBASE_TYPE           int64_t
+#define portUBASE_TYPE          uint64_t
+#define portPOINTER_SIZE_TYPE   uint64_t
+
+typedef portSTACK_TYPE          StackType_t;
+typedef portBASE_TYPE           BaseType_t;
+typedef portUBASE_TYPE          UBaseType_t;
+typedef portUBASE_TYPE          TickType_t;
+
+#define portMAX_DELAY           (0xFFFFFFFFFFFFFFFFUL)
+
+/**
+ *32-bit tick type on a 32-bit architecture
+ *so reads of the tick count do
+ *not need to be guarded with a critical section.
+ **/
+#define portTICK_TYPE_IS_ATOMIC 1
+
+/**
+ * Architecture specific macros.
+ * */
+#define portSTACK_GROWTH            (-1)
+#define portTICK_PERIOD_MS          (( TickType_t ) 1000 / configTICK_RATE_HZ)
+#define portBYTE_ALIGNMENT          (16)
+
+static inline portLONG SaveLocalPSR (void)
+{
+    portLONG flags = csi_irq_save();
+    return flags;
+}
+
+static inline void RestoreLocalPSR (portLONG newMask)
+{
+    csi_irq_restore(newMask);
+}
+
+#if CONFIG_RISCV_FPU_ENABLED
+    #define portTASK_USES_FLOATING_POINT()    pdTRUE
+#else
+    #define portTASK_USES_FLOATING_POINT()    pdFALSE
+#endif
+
+#if configNUMBER_OF_CORES > 1
+    #define portGET_CORE_ID()                       csi_get_cpu_id()
+    #define __FENCE(p, s) __ASM volatile ("fence " #p "," #s : : : "memory")
+    #define mb()        __FENCE(iorw,iorw)
+
+    #define portRTOS_SPINLOCK_COUNT                 (2)
+    typedef volatile uint32_t spin_lock_t;
+    extern spin_lock_t hw_sync_locks[portRTOS_SPINLOCK_COUNT];
+    void SecondaryCoresUp(void);
+    void vPortRecursiveLock(unsigned long ulCoreID, unsigned long ulLockNum, spin_lock_t *pxSpinLock, BaseType_t uxAcquire);
+    void clear_software_irq(int xCoreID);
+    extern volatile UBaseType_t uxYieldCoreAgain[configNUMBER_OF_CORES];
+
+    extern UBaseType_t uxCriticalNestings[ configNUMBER_OF_CORES ];
+    #define portGET_CRITICAL_NESTING_COUNT(xCoreID)            ( uxCriticalNestings[xCoreID] )
+    #define portSET_CRITICAL_NESTING_COUNT(xCoreID, xCount)    ( uxCriticalNestings[xCoreID] = (xCount) )
+    #define portINCREMENT_CRITICAL_NESTING_COUNT(xCoreID)      ( uxCriticalNestings[xCoreID]++ )
+    #define portDECREMENT_CRITICAL_NESTING_COUNT(xCoreID)      ( uxCriticalNestings[xCoreID]-- )
+
+    unsigned long cpu_intrpt_save();
+    void cpu_intrpt_restore(unsigned long ulstate);
+
+    #define portDISABLE_INTERRUPTS()                __ASM volatile("csrc mstatus, 8")
+    #define portENABLE_INTERRUPTS()                 __ASM volatile("csrs mstatus, 8")
+    #define portSET_INTERRUPT_MASK_FROM_ISR()       cpu_intrpt_save();
+    #define portCLEAR_INTERRUPT_MASK_FROM_ISR(x)    cpu_intrpt_restore(x)
+    #define portSET_INTERRUPT_MASK()                cpu_intrpt_save()
+    #define portCLEAR_INTERRUPT_MASK(a)             cpu_intrpt_restore(a)
+    #define portENTER_CRITICAL_FROM_ISR()           vTaskEnterCriticalFromISR()
+    #define portEXIT_CRITICAL_FROM_ISR(a)           vTaskExitCriticalFromISR(a)
+
+    #define portGET_ISR_LOCK(xCoreID)               vPortRecursiveLock(xCoreID, 0, &hw_sync_locks[0], pdTRUE)
+    #define portRELEASE_ISR_LOCK(xCoreID)           vPortRecursiveLock(xCoreID, 0, &hw_sync_locks[0], pdFALSE)
+    #define portGET_TASK_LOCK(xCoreID)              vPortRecursiveLock(xCoreID, 1, &hw_sync_locks[1], pdTRUE)
+    #define portRELEASE_TASK_LOCK(xCoreID)          vPortRecursiveLock(xCoreID, 1, &hw_sync_locks[1], pdFALSE)
+    void vPortYield_Core(int xCoreID);
+    #define portYIELD_CORE(a)                       vPortYield_Core(a)
+    #define portENTER_CRITICAL()                    vTaskEnterCritical()
+    #define portEXIT_CRITICAL()                     vTaskExitCritical()
+#else  /* configNUMBER_OF_CORES > 1 */
+    void vPortEnterCritical(void);
+    void vPortExitCritical(void);
+    void clear_software_irq(int xCoreID);
+    void vPortYield_Core(int xCoreID);
+    void vPortEnableInterrupt(void);
+    void vPortDisableInterrupt(void);
+    #define portDISABLE_INTERRUPTS()                vPortDisableInterrupt()
+    #define portENABLE_INTERRUPTS()                 vPortEnableInterrupt()
+    #define portSET_INTERRUPT_MASK_FROM_ISR()       SaveLocalPSR()
+    #define portCLEAR_INTERRUPT_MASK_FROM_ISR(a)    RestoreLocalPSR(a)
+    #define portENTER_CRITICAL()                    vPortEnterCritical()
+    #define portEXIT_CRITICAL()                     vPortExitCritical()
+#endif /* configNUMBER_OF_CORES > 1 */
+
+#if configGENERATE_RUN_TIME_STATS
+    #define portGET_RUN_TIME_COUNTER_VALUE()        csi_tick_get_ms()
+    #define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()
+#endif
+
+#define portNOP() __asm volatile                    (" nop ")
+
+extern portLONG ulCriticalNesting;
+extern portLONG pendsvflag;
+
+/* Scheduler utilities. */
+extern void vPortYield( void );
+#define portYIELD()                 vPortYield();
+
+/* Added as there is no such function in FreeRTOS. */
+extern void *pvPortRealloc( uint8_t *srcaddr,size_t xWantedSize );
+
+/* Task function macros as described on the FreeRTOS.org WEB site. */
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters ) void vFunction( void *pvParameters ) __attribute__((noreturn))
+#define portTASK_FUNCTION( vFunction, pvParameters ) void vFunction( void *pvParameters )
+
+#define portEND_SWITCHING_ISR( xSwitchRequired )    do {    \
+                                                            if( xSwitchRequired != pdFALSE )    \
+                                                            {   \
+                                                                portYIELD();    \
+                                                            }   \
+                                                    } while(0)
+
+#define portYIELD_FROM_ISR( a )     portEND_SWITCHING_ISR( a )
+
+#define portINLINE	static inline
+
+#ifndef portFORCE_INLINE
+    #define portFORCE_INLINE static inline __attribute__(( always_inline))
+#endif
+
+#ifdef __cplusplus
+    }
+#endif
+
+#endif /* PORTMACRO_H */


### PR DESCRIPTION
Description
-----------
+ Context switch implementations for Alibaba Xuantie C908/C908V CPU
+ FPU and vector extensions are supported
+ SMP is supported

Test Steps
-----------
+ See [DEMO](https://github.com/FreeRTOS/FreeRTOS-Community-Supported-Demos/compare/main...hongfei-poon:FreeRTOS-Community-Supported-Demos:add-c908?expand=1)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
